### PR TITLE
fix(style-strategy): validate method returns correct validation message

### DIFF
--- a/src/styles/style-strategy.ts
+++ b/src/styles/style-strategy.ts
@@ -19,7 +19,7 @@ export interface StyleStrategy {
 export const styleStrategy: Function = (<any>protocol).create('aurelia:style-strategy', {
   validate(target: any): string | boolean {
     if (!(typeof target.loadStyleFactory === 'function')) {
-      return 'Style strategies must implement: loadStyleStrateg(): Promise<StyleFactory>';
+      return 'Style strategies must implement: loadStyleFactory(): Promise<StyleFactory>';
     }
 
     return true;


### PR DESCRIPTION
Noticed a typo/ incorrect error message while reading through the code / trying to understand it's inner workings.

Don't know the best way to report this, so just created a pull.