### PR TITLE
Material Design shadows

### DIFF
--- a/src/button/ux-button-theme.css
+++ b/src/button/ux-button-theme.css
@@ -44,7 +44,7 @@ styles.button.raised, styles.button.fab {
 styles.button.raised {
   transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   transition-delay: 0.2s;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+  box-shadow: ${$design.elevation2dp};
 }
 
 styles.button.raised.disabled, styles.button.fab.disabled {
@@ -53,9 +53,15 @@ styles.button.raised.disabled, styles.button.fab.disabled {
 }
 
 styles.button.raised:active {
-  box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: ${$design.elevation4dp};
   transition-delay: 0s;
 }
+
+styles.button.raised:focus {
+  box-shadow: ${$design.elevationFocus};
+  transition-delay: 0s;
+}
+
 
 styles.button.flat {
   background-color: transparent;
@@ -75,7 +81,7 @@ styles.button.fab {
   overflow: hidden;
   transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   transition-delay: 0.2s;
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+  box-shadow: ${$design.elevation2dp};
 }
 
 styles.button.fab.small {
@@ -94,7 +100,12 @@ styles.button.fab.large {
 }
 
 styles.button.fab:active {
-  box-shadow: 0 8px 17px 0 rgba(0, 0, 0, 0.2);
+  box-shadow: ${$design.elevation4dp};
+  transition-delay: 0s;
+}
+
+styles.button.fab:focus {
+  box-shadow: ${$design.elevationFocus};
   transition-delay: 0s;
 }
 

--- a/src/colors/shadows.ts
+++ b/src/colors/shadows.ts
@@ -1,0 +1,26 @@
+export const shadows = {
+  depth_0:      'none',
+  depth_2dp:    '0 2px 2px 0 rgba(0, 0, 0, 0.14),' +
+                '0 3px 1px -2px rgba(0, 0, 0, 0.2),' +
+                '0 1px 5px 0 rgba(0, 0, 0, 0.12)',
+  depth_3dp:    '0 3px 4px 0 rgba(0, 0, 0, 0.14),' +
+                '0 3px 3px -2px rgba(0, 0, 0, 0.2),' +
+                '0 1px 8px 0 rgba(0, 0, 0, 0.12)',
+  depth_4dp:    '0 4px 5px 0 rgba(0, 0, 0, 0.14),' +
+                '0 1px 10px 0 rgba(0, 0, 0, 0.12),' +
+                '0 2px 4px -1px rgba(0, 0, 0, 0.2)',
+  depth_6dp:    '0 6px 10px 0 rgba(0, 0, 0, 0.14),' +
+                '0 1px 18px 0 rgba(0, 0, 0, 0.12),' +
+                '0 3px 5px -1px rgba(0, 0, 0, 0.2)',
+  depth_8dp:    '0 8px 10px 1px rgba(0, 0, 0, 0.14),' +
+                '0 3px 14px 2px rgba(0, 0, 0, 0.12),' +
+                '0 5px 5px -3px rgba(0, 0, 0, 0.2)',
+  depth_16dp:   '0 16px 24px 2px rgba(0, 0, 0, 0.14),' +
+                '0 6px 30px 5px rgba(0, 0, 0, 0.12),' +
+                '0 8px 10px -5px rgba(0, 0, 0, 0.2)',
+  depth_24dp:   '0 9px 46px  8px rgba(0, 0, 0, 0.14),' +
+                '0 11px 15px -7px rgba(0, 0, 0, 0.12),' +
+                '0 24px 38px  3px rgba(0, 0, 0, 0.2)',
+  depth_focus:  '0 0 8px rgba(0,0,0,.18),' +
+                '0 8px 16px rgba(0,0,0,.36)'
+};

--- a/src/designs/ios-design.ts
+++ b/src/designs/ios-design.ts
@@ -1,5 +1,6 @@
 import {Design} from './design';
 import {swatches} from '../colors/swatches';
+import {shadows} from '../colors/shadows';
 
 export class IOSDesign implements Design {
   public type = 'ios';
@@ -21,4 +22,14 @@ export class IOSDesign implements Design {
 
   public accentDark = swatches.pink.a400;
   public accentDarkForeground = swatches.white;
+
+  public elevationNone = shadows.depth_0;
+  public elevation2dp = shadows.depth_2dp;
+  public elevation3dp = shadows.depth_3dp;
+  public elevation4dp = shadows.depth_4dp;
+  public elevation6dp = shadows.depth_6dp;
+  public elevation8dp = shadows.depth_8dp;
+  public elevation16dp = shadows.depth_16dp;
+  public elevation24dp = shadows.depth_24dp;
+  public elevationFocus = shadows.depth_focus;
 }

--- a/src/designs/material-design.ts
+++ b/src/designs/material-design.ts
@@ -1,5 +1,6 @@
 import {Design} from './design';
 import {swatches} from '../colors/swatches';
+import {shadows} from '../colors/shadows';
 
 export class MaterialDesign implements Design {
   public type = 'material';
@@ -21,7 +22,7 @@ export class MaterialDesign implements Design {
 
   public accentDark = swatches.pink.a400;
   public accentDarkForeground = swatches.white;
-  
+
   public elevationNone = shadows.depth_0;
   public elevation2dp = shadows.depth_2dp;
   public elevation3dp = shadows.depth_3dp;
@@ -31,5 +32,4 @@ export class MaterialDesign implements Design {
   public elevation16dp = shadows.depth_16dp;
   public elevation24dp = shadows.depth_24dp;
   public elevationFocus = shadows.depth_focus;
-  
 }

--- a/src/designs/material-design.ts
+++ b/src/designs/material-design.ts
@@ -21,4 +21,15 @@ export class MaterialDesign implements Design {
 
   public accentDark = swatches.pink.a400;
   public accentDarkForeground = swatches.white;
+  
+  public elevationNone = shadows.depth_0;
+  public elevation2dp = shadows.depth_2dp;
+  public elevation3dp = shadows.depth_3dp;
+  public elevation4dp = shadows.depth_4dp;
+  public elevation6dp = shadows.depth_6dp;
+  public elevation8dp = shadows.depth_8dp;
+  public elevation16dp = shadows.depth_16dp;
+  public elevation24dp = shadows.depth_24dp;
+  public elevationFocus = shadows.depth_focus;
+  
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {FrameworkConfiguration} from 'aurelia-framework';
 import {AureliaUX} from './aurelia-ux';
 
 export {swatches} from './colors/swatches';
+export {shadows} from './colors/shadows';
 export {UxButtonTheme} from './button/ux-button-theme';
 export * from './styles/decorators';
 export {AureliaUX} from './aurelia-ux';

--- a/src/styles/style-factory.ts
+++ b/src/styles/style-factory.ts
@@ -4,6 +4,7 @@ import {computedFrom, camelCase} from 'aurelia-binding';
 import {Container} from 'aurelia-dependency-injection';
 import {Origin} from 'aurelia-metadata';
 import {swatches} from '../colors/swatches';
+import {shadows} from '../colors/shadows';
 
 export class StyleFactory {
   public themeKey: string;
@@ -61,6 +62,7 @@ class StyleOverrideContext {
   public $on = '(min-width: 0)';
   public $off = '(max-width: 0)';
   public $swatches = swatches;
+  public $shadows = shadows;
 
   constructor(public $ux: AureliaUX, public $styles: any, public bindingContext: any) {}
 


### PR DESCRIPTION
Added box-shadow shadow/elevation design resources, updated the material-design and ios-design themes to include references to these new resources so they can be applied using the $design. notation in component themes. 

Updated the ux-button theme to use the new shadow styles and added a new style to the button for the :focus state. 