### PR TITLE
feat(form): add form layout and labels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.formatOnSave": true,
+  // editor.formatOnSave setting causes issues when trying to save changes to CSS files that have binding mixed in
+  "editor.formatOnSave": false, 
   "typescript.format.enable": true,
   "json.format.enable": false,
   "html.format.enable": false,

--- a/src/button/ux-button-theme.css
+++ b/src/button/ux-button-theme.css
@@ -13,7 +13,7 @@ styles.button::-moz-focus-inner {
 
 styles.button.raised, styles.button.flat {
   min-width: 88px;
-  margin: 6px 8px;
+  margin: 6px 0px;
   padding: 0 16px 0 16px;  
   border-radius: 2px;
 }

--- a/src/form/ux-field-theme.css
+++ b/src/form/ux-field-theme.css
@@ -1,0 +1,11 @@
+styles.field {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-top: 16px;
+}
+
+styles.field > label {
+    font-size: 12px;
+    color: ${labelColor || $swatches.grey.p500};
+}

--- a/src/form/ux-field-theme.css
+++ b/src/form/ux-field-theme.css
@@ -6,6 +6,6 @@ styles.field {
 }
 
 styles.field > label {
-    font-size: 12px;
+    font-size: ${labelFontSize};
     color: ${labelColor || $swatches.grey.p500};
 }

--- a/src/form/ux-field-theme.ts
+++ b/src/form/ux-field-theme.ts
@@ -1,0 +1,9 @@
+import { styles } from '../styles/decorators';
+
+@styles()
+export class UxFieldTheme {
+  public background: string;
+  public foreground: string;
+
+  public labelColor: string = '#444';
+}

--- a/src/form/ux-field-theme.ts
+++ b/src/form/ux-field-theme.ts
@@ -6,4 +6,5 @@ export class UxFieldTheme {
   public foreground: string;
 
   public labelColor: string = '#444';
+  public labelFontSize: string = '12px';
 }

--- a/src/form/ux-field.html
+++ b/src/form/ux-field.html
@@ -1,0 +1,5 @@
+<template styles.field>
+  <require from="./ux-field-theme"></require>
+
+  <slot></slot>
+</template>

--- a/src/form/ux-field.ts
+++ b/src/form/ux-field.ts
@@ -1,0 +1,35 @@
+import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { inject } from 'aurelia-dependency-injection';
+import { StyleEngine } from '../styles/style-engine';
+import { Themable } from '../styles/themable';
+import { processDesignAttributes } from '../designs/design-attributes';
+
+@inject(ViewResources, StyleEngine)
+@customElement('ux-field')
+@processAttributes(processDesignAttributes)
+
+export class UxField implements Themable {
+    @bindable public theme = null;
+
+    public view: View;
+
+    constructor(public resources: ViewResources, private styleEngine: StyleEngine) { }
+
+    public created(_: any, myView: View) {
+        this.view = myView;
+    }
+
+    public bind() {
+        if (this.theme) {
+            this.styleEngine.applyTheme(this, this.theme);
+        }
+    }
+
+    // public attached() { }
+
+    // public detached() { }
+
+    public themeChanged(newValue: any) {
+        this.styleEngine.applyTheme(this, newValue);
+    }
+}

--- a/src/form/ux-field.ts
+++ b/src/form/ux-field.ts
@@ -4,16 +4,17 @@ import { StyleEngine } from '../styles/style-engine';
 import { Themable } from '../styles/themable';
 import { processDesignAttributes } from '../designs/design-attributes';
 
-@inject(ViewResources, StyleEngine)
+@inject(Element, ViewResources, StyleEngine)
 @customElement('ux-field')
 @processAttributes(processDesignAttributes)
 
 export class UxField implements Themable {
     @bindable public theme = null;
+    @bindable public label: string;
 
     public view: View;
 
-    constructor(public resources: ViewResources, private styleEngine: StyleEngine) { }
+    constructor(private element: Element, public resources: ViewResources, private styleEngine: StyleEngine) { }
 
     public created(_: any, myView: View) {
         this.view = myView;
@@ -22,6 +23,13 @@ export class UxField implements Themable {
     public bind() {
         if (this.theme) {
             this.styleEngine.applyTheme(this, this.theme);
+        }
+
+        if (this.label && !this.element.closest('label')) {
+            const newLabel = document.createElement('label');
+            newLabel.textContent = this.label;
+
+            this.element.insertBefore(newLabel, this.element.firstChild);
         }
     }
 

--- a/src/form/ux-field.ts
+++ b/src/form/ux-field.ts
@@ -24,9 +24,12 @@ export class UxField implements Themable {
         if (this.theme) {
             this.styleEngine.applyTheme(this, this.theme);
         }
+    }
 
-        if (this.label && !this.element.closest('label')) {
+    public attached() {
+        if (this.label && !this.element.querySelector('label')) {
             const newLabel = document.createElement('label');
+
             newLabel.textContent = this.label;
 
             this.element.insertBefore(newLabel, this.element.firstChild);

--- a/src/form/ux-field.ts
+++ b/src/form/ux-field.ts
@@ -33,10 +33,6 @@ export class UxField implements Themable {
         }
     }
 
-    // public attached() { }
-
-    // public detached() { }
-
     public themeChanged(newValue: any) {
         this.styleEngine.applyTheme(this, newValue);
     }

--- a/src/form/ux-form-theme.css
+++ b/src/form/ux-form-theme.css
@@ -10,7 +10,8 @@ styles.form .form-row {
 }
 
 styles.form .form-row>* {    
-  margin: 0 8px;
+  margin-left: 8px;
+  margin-right: 8px;
 }
 
 styles.form .form-row>*:last-child {

--- a/src/form/ux-form-theme.css
+++ b/src/form/ux-form-theme.css
@@ -1,0 +1,22 @@
+styles.form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+styles.form .form-row {
+  display: flex;
+  flex-direction: row;
+}
+
+styles.form .form-row>* {    
+  margin: 0 8px;
+}
+
+styles.form .form-row>*:last-child {
+  margin-right: 0;
+}
+
+styles.form .form-row>*:first-child {
+  margin-left: 0;
+}

--- a/src/form/ux-form-theme.ts
+++ b/src/form/ux-form-theme.ts
@@ -1,0 +1,9 @@
+import { styles } from '../styles/decorators';
+
+@styles()
+export class UxFormTheme {
+  public background: string = 'transparent';
+  public foreground: string;
+
+  public formPadding: 8;
+}

--- a/src/form/ux-form.html
+++ b/src/form/ux-form.html
@@ -1,0 +1,5 @@
+<template role="form" styles.form>
+  <require from="./ux-form-theme"></require>
+
+  <slot></slot>
+</template>

--- a/src/form/ux-form.ts
+++ b/src/form/ux-form.ts
@@ -1,19 +1,21 @@
 import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { DOM } from 'aurelia-pal';
 import { inject } from 'aurelia-dependency-injection';
 import { StyleEngine } from '../styles/style-engine';
 import { Themable } from '../styles/themable';
 import { processDesignAttributes } from '../designs/design-attributes';
 
-@inject(ViewResources, StyleEngine)
+@inject(Element, ViewResources, StyleEngine)
 @customElement('ux-form')
 @processAttributes(processDesignAttributes)
 
 export class UxForm implements Themable {
     @bindable public theme = null;
+    @bindable public submit: any;
 
     public view: View;
 
-    constructor(public resources: ViewResources, private styleEngine: StyleEngine) { }
+    constructor(private element: Element, public resources: ViewResources, private styleEngine: StyleEngine) { }
 
     public created(_: any, myView: View) {
         this.view = myView;
@@ -25,12 +27,15 @@ export class UxForm implements Themable {
         }
     }
 
-    // public attached() { }
-
-    // public detached() { }
-
-
     public themeChanged(newValue: any) {
         this.styleEngine.applyTheme(this, newValue);
+    }
+
+    public submitForm() {
+        if (this.submit) {
+            const submitEvent = DOM.createCustomEvent('submit', { bubbles: true, target: this.element });
+
+            this.element.dispatchEvent(submitEvent);
+        }
     }
 }

--- a/src/form/ux-form.ts
+++ b/src/form/ux-form.ts
@@ -11,9 +11,10 @@ import { processDesignAttributes } from '../designs/design-attributes';
 
 export class UxForm implements Themable {
     @bindable public theme = null;
-    @bindable public submit: any;
+    @bindable public submitOnEnter: any;
 
     public view: View;
+    private bindSubmitToEnter: boolean = false;
 
     constructor(private element: Element, public resources: ViewResources, private styleEngine: StyleEngine) { }
 
@@ -25,6 +26,30 @@ export class UxForm implements Themable {
         if (this.theme) {
             this.styleEngine.applyTheme(this, this.theme);
         }
+
+        if (this.submitOnEnter !== undefined) {
+            this.bindSubmitToEnter = true;
+        }
+    }
+
+    public attached() {
+        if (this.bindSubmitToEnter) {
+            this.element.addEventListener('keyup', (e: KeyboardEvent) => {
+                if (e.keyCode === 13) {
+                    this.submitForm();
+                }
+            });
+        }
+    }
+
+    public detached() {
+        if (this.bindSubmitToEnter) {
+            this.element.removeEventListener('keyup', (e: KeyboardEvent) => {
+                if (e.keyCode === 13) {
+                    this.submitForm();
+                }
+            });
+        }
     }
 
     public themeChanged(newValue: any) {
@@ -32,10 +57,8 @@ export class UxForm implements Themable {
     }
 
     public submitForm() {
-        if (this.submit) {
-            const submitEvent = DOM.createCustomEvent('submit', { bubbles: true, target: this.element });
+        const submitEvent = DOM.createCustomEvent('submit', { bubbles: true, target: this.element });
 
-            this.element.dispatchEvent(submitEvent);
-        }
+        this.element.dispatchEvent(submitEvent);
     }
 }

--- a/src/form/ux-form.ts
+++ b/src/form/ux-form.ts
@@ -1,0 +1,36 @@
+import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { inject } from 'aurelia-dependency-injection';
+import { StyleEngine } from '../styles/style-engine';
+import { Themable } from '../styles/themable';
+import { processDesignAttributes } from '../designs/design-attributes';
+
+@inject(ViewResources, StyleEngine)
+@customElement('ux-form')
+@processAttributes(processDesignAttributes)
+
+export class UxForm implements Themable {
+    @bindable public theme = null;
+
+    public view: View;
+
+    constructor(public resources: ViewResources, private styleEngine: StyleEngine) { }
+
+    public created(_: any, myView: View) {
+        this.view = myView;
+    }
+
+    public bind() {
+        if (this.theme) {
+            this.styleEngine.applyTheme(this, this.theme);
+        }
+    }
+
+    // public attached() { }
+
+    // public detached() { }
+
+
+    public themeChanged(newValue: any) {
+        this.styleEngine.applyTheme(this, newValue);
+    }
+}

--- a/src/form/ux-submit-attribute.ts
+++ b/src/form/ux-submit-attribute.ts
@@ -1,0 +1,38 @@
+import { inject } from 'aurelia-dependency-injection';
+import { DOM } from 'aurelia-pal';
+
+@inject(Element)
+export class UxSubmitCustomAttribute {
+    public submitEvent: CustomEvent;
+    private canSubmit: boolean = false;
+
+    constructor(public element: Element) { }
+
+    public attached() {
+        let currentParent = this.element.parentElement;
+
+        while (currentParent != null) {
+            if (currentParent.tagName === 'UX-FORM') {
+
+                this.canSubmit = true;
+                this.submitEvent = DOM.createCustomEvent('submit', { bubbles: true });
+
+                this.element.addEventListener('mouseup', () => {
+                    this.element.dispatchEvent(this.submitEvent);
+                });
+
+                break;
+            }
+
+            currentParent = currentParent.parentElement;
+        }
+    }
+
+    public detached() {
+        if (this.canSubmit) {
+            this.element.removeEventListener('mouseup', () => {
+                this.element.dispatchEvent(this.submitEvent);
+            });
+        }
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,8 @@ export function configure(config: FrameworkConfiguration, callback?: (config: Au
     './input-info/ux-input-info',
     './textarea/ux-textarea',
     './form/ux-form',
-    './form/ux-field'
+    './form/ux-field',
+    './form/ux-submit-attribute'
   ]);
 
   const ux = config.container.get(AureliaUX) as AureliaUX;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,16 @@ import { AureliaUX } from './aurelia-ux';
 
 export { swatches } from './colors/swatches';
 export { shadows } from './colors/shadows';
+
 export { UxButtonTheme } from './button/ux-button-theme';
 export { UxInputTheme } from './input/ux-input-theme';
 export { UxInputInfoTheme } from './input-info/ux-input-info-theme';
 export { UxTextareaTheme } from './textarea/ux-textarea-theme';
 export { UxFormTheme } from './form/ux-form-theme';
+export { UxFieldTheme } from './form/ux-field-theme';
+
 export * from './styles/decorators';
+
 export { AureliaUX } from './aurelia-ux';
 export { UXConfiguration } from './ux-configuration';
 
@@ -18,7 +22,8 @@ export function configure(config: FrameworkConfiguration, callback?: (config: Au
     './input/ux-input',
     './input-info/ux-input-info',
     './textarea/ux-textarea',
-    './form/ux-form'
+    './form/ux-form',
+    './form/ux-field'
   ]);
 
   const ux = config.container.get(AureliaUX) as AureliaUX;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,24 @@
-import {FrameworkConfiguration} from 'aurelia-framework';
-import {AureliaUX} from './aurelia-ux';
+import { FrameworkConfiguration } from 'aurelia-framework';
+import { AureliaUX } from './aurelia-ux';
 
-export {swatches} from './colors/swatches';
-export {shadows} from './colors/shadows';
-export {UxButtonTheme} from './button/ux-button-theme';
-export {UxInputTheme} from './input/ux-input-theme';
-export {UxInputInfoTheme} from './input-info/ux-input-info-theme';
-export {UxTextareaTheme} from './textarea/ux-textarea-theme';
+export { swatches } from './colors/swatches';
+export { shadows } from './colors/shadows';
+export { UxButtonTheme } from './button/ux-button-theme';
+export { UxInputTheme } from './input/ux-input-theme';
+export { UxInputInfoTheme } from './input-info/ux-input-info-theme';
+export { UxTextareaTheme } from './textarea/ux-textarea-theme';
+export { UxFormTheme } from './form/ux-form-theme';
 export * from './styles/decorators';
-export {AureliaUX} from './aurelia-ux';
-export {UXConfiguration} from './ux-configuration';
+export { AureliaUX } from './aurelia-ux';
+export { UXConfiguration } from './ux-configuration';
 
 export function configure(config: FrameworkConfiguration, callback?: (config: AureliaUX) => Promise<any>) {
   config.globalResources([
     './button/ux-button',
     './input/ux-input',
     './input-info/ux-input-info',
-    './textarea/ux-textarea'
+    './textarea/ux-textarea',
+    './form/ux-form'
   ]);
 
   const ux = config.container.get(AureliaUX) as AureliaUX;

--- a/src/input-info/ux-input-info-theme.css
+++ b/src/input-info/ux-input-info-theme.css
@@ -1,26 +1,34 @@
-ux-input-info {
+styles.inputinfo {
   display: flex;
   font-size: 14px;
   width: 100%;
   color: ${hintText || $design.primaryLightForeground};
 }
 
-  ux-input-info>.hint-text {
+  styles.inputinfo>.hint-text,
+  styles.inputinfo>.error-text {
     flex-grow: 1;
   }
 
-  ux-input-info>.counter {
-    transition: 250ms;
+  styles.inputinfo>.error-text+.hint-text {
+    display:none;
   }
 
-  ux-input.focused+ux-input-info>.counter {
+  styles.inputinfo>.counter {
+    transition: 250ms;
+    flex-wrap: nowrap;
+    display: flex;
+  }
+
+  ux-input.focused+styles.inputinfo>.counter {
     color: ${$design.accent};
   }
 
-  ux-input>styles.input[disabled]+ux-input-info {
+  ux-input>styles.input[disabled]+styles.inputinfo {
     display: none;
   }
 
-  .has-error+ux-input-info {
+  .has-error+styles.inputinfo {
     color: ${errorAccent || $swatches.red.p500};
   }
+

--- a/src/input-info/ux-input-info-theme.css
+++ b/src/input-info/ux-input-info-theme.css
@@ -1,6 +1,5 @@
 ux-input-info {
   display: flex;
-  margin-top: 4px;
   font-size: 14px;
   width: 100%;
   color: ${hintText || $design.primaryLightForeground};

--- a/src/input-info/ux-input-info.html
+++ b/src/input-info/ux-input-info.html
@@ -1,4 +1,4 @@
-<template>
+<template styles.inputinfo>
   <require from="./ux-input-info-theme"></require>
 
   <span class="hint-text">

--- a/src/input-info/ux-input-info.ts
+++ b/src/input-info/ux-input-info.ts
@@ -13,9 +13,10 @@ export class UxInputInfo implements Themable {
   @bindable public uxInputCounter = null;
   @bindable public theme = null;
 
+  public inputElementModel: any;
   public view: View;
 
-  constructor(public resources: ViewResources, private styleEngine: StyleEngine) { }
+  constructor(private element: Element, public resources: ViewResources, private styleEngine: StyleEngine) { }
 
   public created(_: any, myView: View) {
     this.view = myView;
@@ -25,9 +26,25 @@ export class UxInputInfo implements Themable {
     if (this.theme) {
       this.styleEngine.applyTheme(this, this.theme);
     }
+
+    if (this.target === undefined) {
+      this.findAndSetTarget(this.element);
+    }
   }
 
   public themeChanged(newValue: any) {
     this.styleEngine.applyTheme(this, newValue);
+  }
+
+  private findAndSetTarget(element: any) {
+    const inputElement = element.previousElementSibling;
+
+    if (!inputElement) {
+      return;
+    }
+
+    if (inputElement.nodeName === 'UX-INPUT' || inputElement.nodeName === 'UX-TEXTAREA') {
+      this.target = inputElement.au.controller.viewModel;
+    }
   }
 }

--- a/src/input/ux-input-theme.css
+++ b/src/input/ux-input-theme.css
@@ -5,20 +5,25 @@ ux-input {
 
   styles.input {
     width: 100%;
-    padding: 16px 0 8px 0;
-    margin-bottom: 8px;
+    padding: 6px 0 4px 0;
+    margin-bottom: 4px;
     border: 0;
     outline: none;
     padding-left:0;
     padding-right:0;
-    transition: 250ms;
+    transition: border-color 250ms ease;
     background-color: ${background};
-    border-bottom: 2px solid ${foreground || $design.primaryLightForeground};
+    border-bottom: 1px solid ${foreground || $design.primaryLightForeground};
   }
 
     styles.input:hover,
     styles.input:focus {
       border-bottom-color: ${$design.accent};
+    }
+
+    styles.input:focus {
+      border-bottom-width: 2px;
+      padding-bottom: 3px;
     }
 
     styles.input[disabled],
@@ -34,7 +39,7 @@ ux-input {
   ux-input.full-width > styles.input {
     padding: 20px 8px;
     font-size: 16px;
-  margin-bottom: 0;
+    margin-bottom: 0;
     border: 1px solid ${$swatches.grey.p200};
     background-color: ${$swatches.white};
   }

--- a/src/input/ux-input-theme.css
+++ b/src/input/ux-input-theme.css
@@ -3,16 +3,12 @@ ux-input {
   width: 100%;
 }
 
-styles.input {
-  display: block;
-  position: relative;
-  width: 100%;
-  padding: 8px;
-  border: 0;
-  outline: none;
-}
-
-  ux-input > styles.input {
+  styles.input {
+    width: 100%;
+    padding: 16px 0 8px 0;
+    margin-bottom: 8px;
+    border: 0;
+    outline: none;
     padding-left:0;
     padding-right:0;
     transition: 250ms;
@@ -20,29 +16,25 @@ styles.input {
     border-bottom: 2px solid ${foreground || $design.primaryLightForeground};
   }
 
-    ux-input > styles.input:hover {
+    styles.input:hover,
+    styles.input:focus {
       border-bottom-color: ${$design.accent};
     }
 
-    ux-input > styles.input:focus {
-      border-bottom-color: ${$design.accentDark};
-    }
-
-    ux-input > styles.input[disabled],
-    ux-input > styles.input[disabled]:hover,
-    ux-input > styles.input[disabled]:focus,
-    ux-input > styles.input[readonly],
-    ux-input > styles.input[readonly]:hover,
-    ux-input > styles.input[readonly]:focus {
+    styles.input[disabled],
+    styles.input[disabled]:hover,
+    styles.input[disabled]:focus,
+    styles.input[readonly],
+    styles.input[readonly]:hover,
+    styles.input[readonly]:focus {
       color: ${foregroundDisabled || $swatches.grey.p500};
       border-bottom: 1px dashed ${foregroundDisabled || $swatches.grey.p300};
     }
 
   ux-input.full-width > styles.input {
-    padding: 20px;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding: 20px 8px;
     font-size: 16px;
+  margin-bottom: 0;
     border: 1px solid ${$swatches.grey.p200};
     background-color: ${$swatches.white};
   }

--- a/src/textarea/ux-textarea-theme.css
+++ b/src/textarea/ux-textarea-theme.css
@@ -2,19 +2,14 @@ ux-textarea {
   display: block;
   width: 100%;
 }
-
-styles.textarea {
-  display: block;
-  position: relative;
-  width: 100%;
-  height: 100%;
-  padding: 8px;
-  border: 0;
-  outline: none;
-  resize: none;
-}
-
-  ux-textarea > styles.textarea {
+  styles.textarea {
+    width: 100%;
+    height: 100%;
+    padding: 16px 0 8px 0;
+    margin-bottom: 8px;
+    border: 0;
+    outline: none;
+    resize: none;
     padding-left:0;
     padding-right:0;
     transition: 250ms;
@@ -22,20 +17,17 @@ styles.textarea {
     border-bottom: 2px solid ${foreground || $design.primaryLightForeground};
   }
 
-    ux-textarea > styles.textarea:hover {
+    styles.textarea:hover,
+    styles.textarea:focus {
       border-bottom-color: ${$design.accent};
     }
 
-    ux-textarea > styles.textarea:focus {
-      border-bottom-color: ${$design.accentDark};
-    }
-
-    ux-textarea > styles.textarea[disabled],
-    ux-textarea > styles.textarea[disabled]:hover,
-    ux-textarea > styles.textarea[disabled]:focus,
-    ux-textarea > styles.textarea[readonly],
-    ux-textarea > styles.textarea[readonly]:hover,
-    ux-textarea > styles.textarea[readonly]:focus {
+    styles.textarea[disabled],
+    styles.textarea[disabled]:hover,
+    styles.textarea[disabled]:focus,
+    styles.textarea[readonly],
+    styles.textarea[readonly]:hover,
+    styles.textarea[readonly]:focus {
       color: ${foregroundDisabled || $swatches.grey.p500};
       border-bottom: 1px dashed ${foregroundDisabled || $swatches.grey.p300};
     }
@@ -45,9 +37,8 @@ styles.textarea {
   }
 
   ux-textarea.full-width > styles.textarea {
-    padding: 20px;
-    padding-left: 8px;
-    padding-right: 8px;
+    padding: 20px 8px;
+    margin-bottom: 0;
     font-size: 16px;
     border: 1px solid ${$swatches.grey.p200};
     background-color: ${$swatches.white};

--- a/src/textarea/ux-textarea-theme.css
+++ b/src/textarea/ux-textarea-theme.css
@@ -5,21 +5,26 @@ ux-textarea {
   styles.textarea {
     width: 100%;
     height: 100%;
-    padding: 16px 0 8px 0;
-    margin-bottom: 8px;
+    padding: 6px 0 4px 0;
+    margin-bottom: 4px;
     border: 0;
     outline: none;
     resize: none;
     padding-left:0;
     padding-right:0;
-    transition: 250ms;
+    transition: border-color 250ms ease;
     background-color: ${background};
-    border-bottom: 2px solid ${foreground || $design.primaryLightForeground};
+    border-bottom: 1px solid ${foreground || $design.primaryLightForeground};
   }
 
     styles.textarea:hover,
     styles.textarea:focus {
       border-bottom-color: ${$design.accent};
+    }
+
+    styles.textarea:focus {
+      border-bottom-width: 2px;
+      padding-bottom: 3px;
     }
 
     styles.textarea[disabled],


### PR DESCRIPTION
Add ux-form component and ux-field component to help with label positioning and form layouts.

Styling
- `.form-row` class to handle a row of fields
- `ux-field` component to handle labels and label positioning
- adding a `label` attribute with a value on the `ux-field` component will cause it to create a label if none exist already.

Submit
You can `submit.delegate="methodName()"` to catch a submit event in the form. This is not a required way of using the form and it can be used purely for styling purposes if one would desire to do so.

- ux-submit attribute, allowing buttons to trigger a submit function (not required to use the form)
- method on the form `submitForm` to trigger a submit event
- adding `submit-on-enter` will force the form as a whole to capture enter keyups triggering the `submitForm` method

Validation
There is a `ValidationRenderer` I made that will be included in the showcase application that makes handling errors very easy if you use the `UX-Form` component combined with the `UX-Field` component. I added styling to the `ux-input-info` component to handle displaying errors better.

Usage
``` html
<ux-form>
  
  <div class="form-row">
    <ux-field label="First Name">
      <ux-input maxlength="10" value.bind="form.firstName & validate"></ux-input>
      <ux-input-info ux-input-counter>John</ux-input-info>
    </ux-field>
    <ux-field label="Last Name">
      <ux-input maxlength="10" value.bind="form.lastName & validate"></ux-input>
      <ux-input-info ux-input-counter>Doe</ux-input-info>
    </ux-field>
  </div>

  <ux-field label="Email Address">
    <ux-input type="email" value.bind="form.email & validate"></ux-input>
    <ux-input-info></ux-input-info>
  </ux-field>

  <ux-button click.delegate="submit()">Button</ux-button>

</ux-form>
```