### PR TITLE
feat(chips): add material chips

### DIFF
--- a/src/chip-input/ux-chip-input-theme.css
+++ b/src/chip-input/ux-chip-input-theme.css
@@ -1,4 +1,44 @@
 styles.chipinput {
-  
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;  
+}
+
+  styles.chipinput>ux-chip,
+  styles.chipinput>ux-tag {
+    margin-right: 6px;
+    cursor: default;
   }
-  
+
+  styles.chipinput>input {
+    align-self: stretch;
+    border: none;
+    flex-grow: 1;
+    min-width: 180px;
+  }
+
+  styles.chipinput>input:focus {
+    outline: none;
+  }
+
+  styles.chipinput>input+div.bottom-border {
+    align-self: flex-end;
+    background-color: ${foreground || $design.primaryLightForeground};
+    height: 1px;
+    margin-top: 2px;
+    margin-bottom: 4px;
+    transition: background-color 250ms ease;
+    width: 100%;
+  }
+
+    styles.chipinput:hover>div.bottom-border,
+    styles.chipinput>input:focus+div.bottom-border {
+      background-color: ${$design.accent};
+    }
+
+    styles.chipinput > input:focus+div.bottom-border {
+      height: 2px;
+      margin-bottom: 3px;
+    }

--- a/src/chip-input/ux-chip-input-theme.css
+++ b/src/chip-input/ux-chip-input-theme.css
@@ -1,0 +1,4 @@
+styles.chipinput {
+  
+  }
+  

--- a/src/chip-input/ux-chip-input-theme.ts
+++ b/src/chip-input/ux-chip-input-theme.ts
@@ -1,0 +1,12 @@
+import {styles} from '../styles/decorators';
+
+@styles()
+export class UxChipInputTheme {
+  public background: string = 'transparent';
+  public foreground: string;
+
+  public backgroundDisabled: string;
+  public foregroundDisabled: string;
+
+  public errorAccent: string;
+}

--- a/src/chip-input/ux-chip-input.html
+++ b/src/chip-input/ux-chip-input.html
@@ -1,22 +1,26 @@
 <template role="textbox" styles.chipinput>
   <require from="./ux-chip-input-theme"></require>
 
+  <template if.bind="type.toLowerCase() !== 'tag'">
     <ux-chip deletable
-             ref="chiprepeat"
-             close.trigger="removeChip(chip)"
-             dblclick.trigger="editChip(chip)"
-             if.bind="type.toLowerCase() !== 'tag'"
-             repeat.for="chip of chipArray">
-             ${chip}
-             </ux-chip>
+      ref="chiprepeat"
+      close.trigger="removeChip(chip)"
+      dblclick.trigger="editChip(chip)"
+      repeat.for="chip of chips">
+      ${chip}
+    </ux-chip>
+  </template>
+  
+  <template if.bind="type.toLowerCase() === 'tag'">
     <ux-tag deletable
-            ref="tagrepeat"
-            close.trigger="removeChip(chip)"
-            dblclick.trigger="editChip(chip)"
-            if.bind="type.toLowerCase() === 'tag'"
-            repeat.for="chip of chipArray">
-            ${chip}
-            </ux-tag>
-    <input ref="textbox" keyup.delegate="handleKeyup($event)"/>
+      ref="tagrepeat"
+      close.trigger="removeChip(chip)"
+      dblclick.trigger="editChip(chip)"
+      repeat.for="chip of chips">
+      ${chip}
+    </ux-tag>
+  </template>
+
+  <input ref="textbox" keyup.delegate="handleKeyup($event)"/>
   <div class="bottom-border"></div>
 </template>

--- a/src/chip-input/ux-chip-input.html
+++ b/src/chip-input/ux-chip-input.html
@@ -1,6 +1,20 @@
 <template role="textbox" styles.chipinput>
   <require from="./ux-chip-input-theme"></require>
 
-  <input ref="textbox" value.bind="value" />
-
+    <ux-chip deletable
+             close.trigger="removeChip(chip)"
+             dblclick.trigger="editChip(chip)"
+             if.bind="type.toLowerCase() !== 'tag'"
+             repeat.for="chip of chipArray">
+             ${chip}
+             </ux-chip>
+    <ux-tag deletable
+            close.trigger="removeChip(chip)"
+            dblclick.trigger="editChip(chip)"
+            if.bind="type.toLowerCase() === 'tag'"
+            repeat.for="chip of chipArray">
+            ${chip}
+            </ux-tag>
+    <input ref="textbox" keyup.delegate="handleKeyup($event)"/>
+  <div class="bottom-border"></div>
 </template>

--- a/src/chip-input/ux-chip-input.html
+++ b/src/chip-input/ux-chip-input.html
@@ -2,6 +2,7 @@
   <require from="./ux-chip-input-theme"></require>
 
     <ux-chip deletable
+             ref="chiprepeat"
              close.trigger="removeChip(chip)"
              dblclick.trigger="editChip(chip)"
              if.bind="type.toLowerCase() !== 'tag'"
@@ -9,6 +10,7 @@
              ${chip}
              </ux-chip>
     <ux-tag deletable
+            ref="tagrepeat"
             close.trigger="removeChip(chip)"
             dblclick.trigger="editChip(chip)"
             if.bind="type.toLowerCase() === 'tag'"

--- a/src/chip-input/ux-chip-input.html
+++ b/src/chip-input/ux-chip-input.html
@@ -1,0 +1,6 @@
+<template role="textbox" styles.chipinput>
+  <require from="./ux-chip-input-theme"></require>
+
+  <input ref="textbox" value.bind="value" />
+
+</template>

--- a/src/chip-input/ux-chip-input.ts
+++ b/src/chip-input/ux-chip-input.ts
@@ -15,9 +15,13 @@ export class UxChipInput implements Themable {
   @bindable public readonly: any = false;
   @bindable public theme = null;
   @bindable public type: any;
+  @bindable public seperator: string;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay })
   public value: any = undefined;
+
+  @bindable({ defaultBindingMode: bindingMode.twoWay })
+  public chipArray: Array<any> = new Array<any>();
 
   public view: View;
   private textbox: HTMLInputElement;
@@ -31,11 +35,6 @@ export class UxChipInput implements Themable {
   public bind() {
     if (this.theme) {
       this.styleEngine.applyTheme(this, this.theme);
-    }
-
-    if (this.element.hasAttribute('required')) {
-      this.textbox.setAttribute('required', '');
-      this.element.removeAttribute('required');
     }
 
     if (this.element.hasAttribute('placeholder')) {
@@ -64,6 +63,7 @@ export class UxChipInput implements Themable {
     });
 
     this.textbox.addEventListener('blur', () => {
+      this.addChip();
       this.element.classList.remove('focused');
       this.element.dispatchEvent(blurEvent);
     });
@@ -77,9 +77,70 @@ export class UxChipInput implements Themable {
     });
 
     this.textbox.removeEventListener('blur', () => {
+      this.addChip();
       this.element.classList.remove('focused');
       this.element.dispatchEvent(blurEvent);
     });
+  }
+
+  public handleKeyup(event: KeyboardEvent) {
+    const key = event.which || event.keyCode;
+
+    if (key === 13) {
+      this.addChip();
+    }
+
+    if (key === 37) {
+      if (this.chipArray.length) {
+        this.textbox.value = this.chipArray.pop().toString();
+      }
+    }
+  }
+
+  public addChip() {
+    if (this.textbox.value.length) {
+      this.chipArray.push(this.textbox.value);
+      this.textbox.value = '';
+      this.chipsChanged();
+    }
+  }
+
+  public editChip(value: string) {
+    if (this.textbox.value.length === 0) {
+      this.removeChip(value);
+      this.textbox.value = value;
+      this.chipsChanged();
+    }
+  }
+
+  public removeChip(value: string) {
+    const chipIndex = this.chipArray.indexOf(value, 0);
+
+    if (chipIndex > -1) {
+      this.chipArray.splice(chipIndex, 1);
+      this.chipsChanged();
+    }
+  }
+
+  public chipsChanged() {
+    let seperator = ', ';
+
+    if (this.seperator) {
+      seperator = this.seperator;
+    }
+
+    this.value = this.chipArray.join(seperator);
+
+  }
+
+  public valueChanged() {
+    let seperator = ', ';
+
+    if (this.seperator) {
+      seperator = this.seperator;
+    }
+
+    this.chipArray = this.value.split(seperator);
   }
 
   public disabledChanged(newValue: any) {

--- a/src/chip-input/ux-chip-input.ts
+++ b/src/chip-input/ux-chip-input.ts
@@ -15,7 +15,7 @@ export class UxChipInput implements Themable {
   @bindable public readonly: any = false;
   @bindable public theme = null;
   @bindable public type: any;
-  @bindable public seperator: string;
+  @bindable public separator: string;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay })
   public value: any = undefined;
@@ -25,6 +25,8 @@ export class UxChipInput implements Themable {
 
   public view: View;
   private textbox: HTMLInputElement;
+  private chiprepeat: Element;
+  private tagrepeat: Element;
 
   constructor(private element: HTMLInputElement, public resources: ViewResources, private styleEngine: StyleEngine) { }
 
@@ -48,10 +50,14 @@ export class UxChipInput implements Themable {
 
     if (this.disabled || this.disabled === '') {
       this.textbox.setAttribute('disabled', '');
+      this.chiprepeat.removeAttribute('deletable');
+      this.tagrepeat.removeAttribute('deletable');
     }
 
     if (this.readonly || this.readonly === '') {
       this.textbox.setAttribute('readonly', '');
+      this.chiprepeat.removeAttribute('deletable');
+      this.tagrepeat.removeAttribute('deletable');
     }
   }
 
@@ -125,19 +131,18 @@ export class UxChipInput implements Themable {
   public chipsChanged() {
     let seperator = ', ';
 
-    if (this.seperator) {
-      seperator = this.seperator;
+    if (this.separator) {
+      seperator = this.separator;
     }
 
     this.value = this.chipArray.join(seperator);
-
   }
 
   public valueChanged() {
     let seperator = ', ';
 
-    if (this.seperator) {
-      seperator = this.seperator;
+    if (this.separator) {
+      seperator = this.separator;
     }
 
     this.chipArray = this.value.split(seperator);
@@ -146,16 +151,24 @@ export class UxChipInput implements Themable {
   public disabledChanged(newValue: any) {
     if (newValue === true || newValue === '') {
       this.textbox.setAttribute('disabled', 'true');
+      this.chiprepeat.removeAttribute('deletable');
+      this.tagrepeat.removeAttribute('deletable');
     } else {
       this.textbox.removeAttribute('disabled');
+      this.chiprepeat.setAttribute('deletable', '');
+      this.tagrepeat.setAttribute('deletable', '');
     }
   }
 
   public readonlyChanged(newValue: any) {
     if (newValue === true || newValue === '') {
       this.textbox.setAttribute('readonly', 'true');
+      this.chiprepeat.removeAttribute('deletable');
+      this.tagrepeat.removeAttribute('deletable');
     } else {
       this.textbox.removeAttribute('readonly');
+      this.chiprepeat.setAttribute('deletable', '');
+      this.tagrepeat.setAttribute('deletable', '');
     }
   }
 

--- a/src/chip-input/ux-chip-input.ts
+++ b/src/chip-input/ux-chip-input.ts
@@ -1,0 +1,104 @@
+import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { DOM } from 'aurelia-pal';
+import { bindingMode } from 'aurelia-binding';
+import { inject } from 'aurelia-dependency-injection';
+import { StyleEngine } from '../styles/style-engine';
+import { Themable } from '../styles/themable';
+import { processDesignAttributes } from '../designs/design-attributes';
+
+@inject(Element, ViewResources, StyleEngine)
+@customElement('ux-chip-input')
+@processAttributes(processDesignAttributes)
+
+export class UxChipInput implements Themable {
+  @bindable public disabled: any = false;
+  @bindable public readonly: any = false;
+  @bindable public theme = null;
+  @bindable public type: any;
+
+  @bindable({ defaultBindingMode: bindingMode.twoWay })
+  public value: any = undefined;
+
+  public view: View;
+  private textbox: HTMLInputElement;
+
+  constructor(private element: HTMLInputElement, public resources: ViewResources, private styleEngine: StyleEngine) { }
+
+  public created(_: any, myView: View) {
+    this.view = myView;
+  }
+
+  public bind() {
+    if (this.theme) {
+      this.styleEngine.applyTheme(this, this.theme);
+    }
+
+    if (this.element.hasAttribute('required')) {
+      this.textbox.setAttribute('required', '');
+      this.element.removeAttribute('required');
+    }
+
+    if (this.element.hasAttribute('placeholder')) {
+      const attributeValue = this.element.getAttribute('placeholder');
+
+      if (attributeValue) {
+        this.textbox.setAttribute('placeholder', attributeValue);
+        this.element.removeAttribute('placeholder');
+      }
+    }
+
+    if (this.disabled || this.disabled === '') {
+      this.textbox.setAttribute('disabled', '');
+    }
+
+    if (this.readonly || this.readonly === '') {
+      this.textbox.setAttribute('readonly', '');
+    }
+  }
+
+  public attached() {
+    const blurEvent = DOM.createCustomEvent('blur', { bubbles: true });
+
+    this.textbox.addEventListener('focus', () => {
+      this.element.classList.add('focused');
+    });
+
+    this.textbox.addEventListener('blur', () => {
+      this.element.classList.remove('focused');
+      this.element.dispatchEvent(blurEvent);
+    });
+  }
+
+  public detached() {
+    const blurEvent = DOM.createCustomEvent('blur', { bubbles: true });
+
+    this.textbox.removeEventListener('focus', () => {
+      this.element.classList.add('focused');
+    });
+
+    this.textbox.removeEventListener('blur', () => {
+      this.element.classList.remove('focused');
+      this.element.dispatchEvent(blurEvent);
+    });
+  }
+
+  public disabledChanged(newValue: any) {
+    if (newValue === true || newValue === '') {
+      this.textbox.setAttribute('disabled', 'true');
+    } else {
+      this.textbox.removeAttribute('disabled');
+    }
+  }
+
+  public readonlyChanged(newValue: any) {
+    if (newValue === true || newValue === '') {
+      this.textbox.setAttribute('readonly', 'true');
+    } else {
+      this.textbox.removeAttribute('readonly');
+    }
+  }
+
+  public themeChanged(newValue: any) {
+    this.styleEngine.applyTheme(this, newValue);
+  }
+}

--- a/src/chip-input/ux-chip-input.ts
+++ b/src/chip-input/ux-chip-input.ts
@@ -21,7 +21,7 @@ export class UxChipInput implements Themable {
   public value: any = undefined;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay })
-  public chipArray: Array<any> = new Array<any>();
+  public chipArray: Array<string> = new Array<string>();
 
   public view: View;
   private textbox: HTMLInputElement;
@@ -97,14 +97,22 @@ export class UxChipInput implements Themable {
     }
 
     if (key === 37) {
-      if (this.chipArray.length) {
-        this.textbox.value = this.chipArray.pop().toString();
+      if (this.chipArray) {
+        const chip = this.chipArray.pop();
+
+        if (chip !== undefined) {
+          this.textbox.value = chip;
+        }
       }
     }
   }
 
   public addChip() {
     if (this.textbox.value.length) {
+      if (!this.chipArray) {
+        this.chipArray = new Array<string>();
+      }
+
       this.chipArray.push(this.textbox.value);
       this.textbox.value = '';
       this.chipsChanged();
@@ -135,21 +143,21 @@ export class UxChipInput implements Themable {
       seperator = this.separator;
     }
 
-    if (this.chipArray) {
-      this.value = this.chipArray.join(seperator);
-    }
+    this.value = this.chipArray.join(seperator);
   }
 
   public valueChanged() {
+    if (this.value === null) {
+      return;
+    }
+
     let seperator = ', ';
 
     if (this.separator) {
       seperator = this.separator;
     }
-    
-    if (this.value) {
-      this.chipArray = this.value.split(seperator);
-    }
+
+    this.chipArray = this.value.split(seperator);
   }
 
   public disabledChanged(newValue: any) {

--- a/src/chip-input/ux-chip-input.ts
+++ b/src/chip-input/ux-chip-input.ts
@@ -21,7 +21,7 @@ export class UxChipInput implements Themable {
   public value: any = undefined;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay })
-  public chipArray: Array<string> = new Array<string>();
+  public chips: Array<string> = new Array<string>();
 
   public view: View;
   private textbox: HTMLInputElement;
@@ -97,8 +97,8 @@ export class UxChipInput implements Themable {
     }
 
     if (key === 37) {
-      if (this.chipArray) {
-        const chip = this.chipArray.pop();
+      if (this.chips) {
+        const chip = this.chips.pop();
 
         if (chip !== undefined) {
           this.textbox.value = chip;
@@ -109,11 +109,11 @@ export class UxChipInput implements Themable {
 
   public addChip() {
     if (this.textbox.value.length) {
-      if (!this.chipArray) {
-        this.chipArray = new Array<string>();
+      if (!this.chips) {
+        this.chips = new Array<string>();
       }
 
-      this.chipArray.push(this.textbox.value);
+      this.chips.push(this.textbox.value);
       this.textbox.value = '';
       this.chipsChanged();
     }
@@ -128,10 +128,10 @@ export class UxChipInput implements Themable {
   }
 
   public removeChip(value: string) {
-    const chipIndex = this.chipArray.indexOf(value, 0);
+    const chipIndex = this.chips.indexOf(value, 0);
 
     if (chipIndex > -1) {
-      this.chipArray.splice(chipIndex, 1);
+      this.chips.splice(chipIndex, 1);
       this.chipsChanged();
     }
   }
@@ -143,7 +143,7 @@ export class UxChipInput implements Themable {
       seperator = this.separator;
     }
 
-    this.value = this.chipArray.join(seperator);
+    this.value = this.chips.join(seperator);
   }
 
   public valueChanged() {
@@ -157,7 +157,7 @@ export class UxChipInput implements Themable {
       seperator = this.separator;
     }
 
-    this.chipArray = this.value.split(seperator);
+    this.chips = this.value.split(seperator);
   }
 
   public disabledChanged(newValue: any) {

--- a/src/chip-input/ux-chip-input.ts
+++ b/src/chip-input/ux-chip-input.ts
@@ -135,7 +135,9 @@ export class UxChipInput implements Themable {
       seperator = this.separator;
     }
 
-    this.value = this.chipArray.join(seperator);
+    if (this.chipArray) {
+      this.value = this.chipArray.join(seperator);
+    }
   }
 
   public valueChanged() {
@@ -144,8 +146,10 @@ export class UxChipInput implements Themable {
     if (this.separator) {
       seperator = this.separator;
     }
-
-    this.chipArray = this.value.split(seperator);
+    
+    if (this.value) {
+      this.chipArray = this.value.split(seperator);
+    }
   }
 
   public disabledChanged(newValue: any) {

--- a/src/chip-input/ux-chip-theme.css
+++ b/src/chip-input/ux-chip-theme.css
@@ -1,0 +1,14 @@
+styles.chip {
+  display: inline-flex;
+  align-items: center;
+
+  font-size: 14px;
+
+  padding: 8px 12px;
+
+  border-radius: 100px;
+
+  background-color: ${background || $design.accent};
+  color: ${foreground || $design.accentForeground};
+
+}

--- a/src/chip-input/ux-chip-theme.css
+++ b/src/chip-input/ux-chip-theme.css
@@ -4,11 +4,45 @@ styles.chip {
 
   font-size: 14px;
 
-  padding: 8px 12px;
-
+  height: 32px;
   border-radius: 100px;
 
   background-color: ${background || $design.accent};
   color: ${foreground || $design.accentForeground};
-
 }
+
+  styles.chip:focus {
+    outline: none;
+    box-shadow: ${$design.elevation4dp};
+  }
+
+  styles.chip > span {
+    margin: 0 12px;
+  }
+
+    styles.chip > span.close {
+      display:none;
+    }
+
+  styles.chip[deletable] > span {
+    margin-right: 0;
+  }
+
+    styles.chip[deletable] > span.close {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 4px;
+      color: ${background || $design.accent};
+      background-color: #a6a6a6;
+      height: 24px;
+      width: 24px;
+      border-radius: 24px;
+      cursor: pointer;
+    }
+
+      styles.chip[deletable] > span.close::before {
+        content: '+';    
+        font-size: 24px;
+        transform: rotate(45deg);
+      }

--- a/src/chip-input/ux-chip-theme.ts
+++ b/src/chip-input/ux-chip-theme.ts
@@ -1,0 +1,7 @@
+import {styles} from '../styles/decorators';
+
+@styles()
+export class UxChipTheme {
+  public background: string = '#e0e0e0';
+  public foreground: string = '#757575';
+}

--- a/src/chip-input/ux-chip.html
+++ b/src/chip-input/ux-chip.html
@@ -1,6 +1,10 @@
 <template role="textbox" styles.chip>
   <require from="./ux-chip-theme"></require>
 
-  <slot></slot>
+  <span>
+    <slot></slot>
+  </span>
 
+  <span class="close" click.delegate="closeChip()">
+  </span>
 </template>

--- a/src/chip-input/ux-chip.html
+++ b/src/chip-input/ux-chip.html
@@ -1,0 +1,6 @@
+<template role="textbox" styles.chip>
+  <require from="./ux-chip-theme"></require>
+
+  <slot></slot>
+
+</template>

--- a/src/chip-input/ux-chip.ts
+++ b/src/chip-input/ux-chip.ts
@@ -1,4 +1,5 @@
 import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { DOM } from 'aurelia-pal';
 import { bindingMode } from 'aurelia-binding';
 import { inject } from 'aurelia-dependency-injection';
 import { StyleEngine } from '../styles/style-engine';
@@ -12,13 +13,14 @@ import { processDesignAttributes } from '../designs/design-attributes';
 export class UxChip implements Themable {
     @bindable public theme = null;
     @bindable public type: any;
+
     @bindable({ defaultBindingMode: bindingMode.twoWay })
     public value: any = undefined;
 
     public view: View;
 
     constructor(
-        /*private element: HTMLInputElement,*/
+        private element: HTMLInputElement,
         public resources: ViewResources,
         private styleEngine: StyleEngine) { }
 
@@ -34,5 +36,11 @@ export class UxChip implements Themable {
 
     public themeChanged(newValue: any) {
         this.styleEngine.applyTheme(this, newValue);
+    }
+
+    public closeChip() {
+        const closeEvent = DOM.createCustomEvent('close', { bubbles: false });
+
+        this.element.dispatchEvent(closeEvent);
     }
 }

--- a/src/chip-input/ux-chip.ts
+++ b/src/chip-input/ux-chip.ts
@@ -1,0 +1,38 @@
+import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { bindingMode } from 'aurelia-binding';
+import { inject } from 'aurelia-dependency-injection';
+import { StyleEngine } from '../styles/style-engine';
+import { Themable } from '../styles/themable';
+import { processDesignAttributes } from '../designs/design-attributes';
+
+@inject(Element, ViewResources, StyleEngine)
+@customElement('ux-chip')
+@processAttributes(processDesignAttributes)
+
+export class UxChip implements Themable {
+    @bindable public theme = null;
+    @bindable public type: any;
+    @bindable({ defaultBindingMode: bindingMode.twoWay })
+    public value: any = undefined;
+
+    public view: View;
+
+    constructor(
+        /*private element: HTMLInputElement,*/
+        public resources: ViewResources,
+        private styleEngine: StyleEngine) { }
+
+    public created(_: any, myView: View) {
+        this.view = myView;
+    }
+
+    public bind() {
+        if (this.theme) {
+            this.styleEngine.applyTheme(this, this.theme);
+        }
+    }
+
+    public themeChanged(newValue: any) {
+        this.styleEngine.applyTheme(this, newValue);
+    }
+}

--- a/src/chip-input/ux-tag-theme.css
+++ b/src/chip-input/ux-tag-theme.css
@@ -4,10 +4,36 @@ styles.tag {
 
   font-size: 14px;
 
-  padding: 2px 6px;
+  height: 24px;
 
   border-radius: 2px;
 
   background-color: ${background || $design.accent};
   color: ${foreground || $design.accentForeground};
 }
+
+styles.tag > span {
+    margin: 0 8px;
+  }
+
+    styles.tag > span.close {
+      display:none;
+    }
+
+  styles.tag[deletable] > span {
+    margin-right: 0;
+  }
+
+    styles.tag[deletable] > span.close {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      margin: 0 4px;
+      cursor: pointer;
+    }
+
+      styles.tag[deletable] > span.close::before {
+        content: '+';    
+        font-size: 24px;
+        transform: rotate(45deg);
+      }

--- a/src/chip-input/ux-tag-theme.css
+++ b/src/chip-input/ux-tag-theme.css
@@ -1,0 +1,13 @@
+styles.tag {
+  display: inline-flex;
+  align-items: center;
+
+  font-size: 14px;
+
+  padding: 2px 6px;
+
+  border-radius: 2px;
+
+  background-color: ${background || $design.accent};
+  color: ${foreground || $design.accentForeground};
+}

--- a/src/chip-input/ux-tag-theme.ts
+++ b/src/chip-input/ux-tag-theme.ts
@@ -1,0 +1,7 @@
+import {styles} from '../styles/decorators';
+
+@styles()
+export class UxTagTheme {
+  public background: string;
+  public foreground: string;
+}

--- a/src/chip-input/ux-tag.html
+++ b/src/chip-input/ux-tag.html
@@ -1,6 +1,10 @@
 <template role="textbox" styles.tag>
   <require from="./ux-tag-theme"></require>
 
-  <slot></slot>
+  <span>
+    <slot></slot>
+  </span>
 
+  <span class="close" click.delegate="closeTag()">
+  </span>
 </template>

--- a/src/chip-input/ux-tag.html
+++ b/src/chip-input/ux-tag.html
@@ -1,0 +1,6 @@
+<template role="textbox" styles.tag>
+  <require from="./ux-tag-theme"></require>
+
+  <slot></slot>
+
+</template>

--- a/src/chip-input/ux-tag.ts
+++ b/src/chip-input/ux-tag.ts
@@ -1,0 +1,38 @@
+import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { bindingMode } from 'aurelia-binding';
+import { inject } from 'aurelia-dependency-injection';
+import { StyleEngine } from '../styles/style-engine';
+import { Themable } from '../styles/themable';
+import { processDesignAttributes } from '../designs/design-attributes';
+
+@inject(Element, ViewResources, StyleEngine)
+@customElement('ux-tag')
+@processAttributes(processDesignAttributes)
+
+export class UxTag implements Themable {
+    @bindable public theme = null;
+    @bindable public type: any;
+    @bindable({ defaultBindingMode: bindingMode.twoWay })
+    public value: any = undefined;
+
+    public view: View;
+
+    constructor(
+        /*private element: HTMLInputElement,*/
+        public resources: ViewResources,
+        private styleEngine: StyleEngine) { }
+
+    public created(_: any, myView: View) {
+        this.view = myView;
+    }
+
+    public bind() {
+        if (this.theme) {
+            this.styleEngine.applyTheme(this, this.theme);
+        }
+    }
+
+    public themeChanged(newValue: any) {
+        this.styleEngine.applyTheme(this, newValue);
+    }
+}

--- a/src/chip-input/ux-tag.ts
+++ b/src/chip-input/ux-tag.ts
@@ -1,4 +1,5 @@
 import { customElement, bindable, ViewResources, View, processAttributes } from 'aurelia-templating';
+import { DOM } from 'aurelia-pal';
 import { bindingMode } from 'aurelia-binding';
 import { inject } from 'aurelia-dependency-injection';
 import { StyleEngine } from '../styles/style-engine';
@@ -18,7 +19,7 @@ export class UxTag implements Themable {
     public view: View;
 
     constructor(
-        /*private element: HTMLInputElement,*/
+        private element: HTMLInputElement,
         public resources: ViewResources,
         private styleEngine: StyleEngine) { }
 
@@ -34,5 +35,11 @@ export class UxTag implements Themable {
 
     public themeChanged(newValue: any) {
         this.styleEngine.applyTheme(this, newValue);
+    }
+
+    public closeTag() {
+        const closeEvent = DOM.createCustomEvent('close', { bubbles: false });
+
+        this.element.dispatchEvent(closeEvent);
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,9 @@ export { UxInputInfoTheme } from './input-info/ux-input-info-theme';
 export { UxTextareaTheme } from './textarea/ux-textarea-theme';
 export { UxFormTheme } from './form/ux-form-theme';
 export { UxFieldTheme } from './form/ux-field-theme';
+export { UxChipInputTheme } from './chip-input/ux-chip-input-theme';
+export { UxTagTheme } from './chip-input/ux-tag-theme';
+export { UxChipTheme } from './chip-input/ux-chip-theme';
 
 export * from './styles/decorators';
 
@@ -24,7 +27,10 @@ export function configure(config: FrameworkConfiguration, callback?: (config: Au
     './textarea/ux-textarea',
     './form/ux-form',
     './form/ux-field',
-    './form/ux-submit-attribute'
+    './form/ux-submit-attribute',
+    './chip-input/ux-chip-input',
+    './chip-input/ux-chip',
+    './chip-input/ux-tag'
   ]);
 
   const ux = config.container.get(AureliaUX) as AureliaUX;


### PR DESCRIPTION
Add Material Design chips, a chip editor, and smaller tags.

![image](https://cloud.githubusercontent.com/assets/22172935/24828017/408bbf6e-1c1a-11e7-9ca2-06730141f43a.png)


Usage
``` html
<!-- Comma Seperated String -->
<ux-chip-input value.bind="commaDelimitedString"></ux-chip-input>

<!-- Custom Seperator -->
<ux-chip-input separator="\;/" value.bind="customDelimitedString"></ux-chip-input>

<!-- Bind Directly To Array -->
<ux-chip-input chip-array.bind="arrayValue"></ux-chip-input>

<!-- Tag -->
<ux-tag repeat.for="keyword of Keywords">${keyword}</ux-tag>

<!-- Tag with 'X' -->
<ux-tag repeat.for="keyword of Keywords" deletable close.trigger="closingChip()">${keyword}</ux-tag>

<!-- Chip -->
<ux-chip repeat.for="keyword of Keywords">${keyword}</ux-chip>

<!-- Chip with 'X' -->
<ux-chip repeat.for="keyword of Keywords" deletable close.trigger="closingChip()">${keyword}</ux-chip>
```

Editor
- remove chip from list
- add chip to list
- double click to edit any chip
- left arrow on empty input to edit newest chip
- enter or tab to add a chip

Chip
- Material Design Style
- Deletable Attribute to expose a delete button that emits a `closed` event when clicked that can be bound to with `close.bind`

Tag
- Deletable Attribute to expose a delete button that emits a `closed` event when clicked that can be bound to with `close.bind`

Resolves: #51 