### PR TITLE
style(input-info): change error display

### DIFF
--- a/src/input-info/ux-input-info-theme.css
+++ b/src/input-info/ux-input-info-theme.css
@@ -9,9 +9,14 @@ styles.inputinfo {
   styles.inputinfo>.error-text {
     flex-grow: 1;
   }
+  styles.inputinfo>.hint-text:first-child,
+  styles.inputinfo>.error-text:first-child {
+    display: block;
+  }
 
-  styles.inputinfo>.error-text+.hint-text {
-    display:none;
+  styles.inputinfo>.hint-text,
+  styles.inputinfo>.error-text {
+    display: none;
   }
 
   styles.inputinfo>.counter {


### PR DESCRIPTION
hides all hint-text and error-text except the first child. resolves an issue where multiple error messages can display at once