### PR TITLE
fix(checkbox): fix delete this.checked issue

### DIFF
--- a/src/checkbox/ux-checkbox.ts
+++ b/src/checkbox/ux-checkbox.ts
@@ -19,10 +19,10 @@ export class UxCheckbox implements Themable {
   @bindable public theme = null;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay })
-  @bindable public checked = false;
+  @bindable public checked: any = false;
 
   @bindable({ defaultBindingMode: bindingMode.twoWay })
-  @bindable public value: any = false;
+  @bindable public value: any = null;
 
   public view: View;
   private checkbox: Element;
@@ -86,9 +86,9 @@ export class UxCheckbox implements Themable {
       }
 
       this.checkedChanged();
-    } else if (typeof elementValue !== 'boolean') {
+    } else if (elementValue != null && typeof elementValue !== 'boolean') {
       if (this.checked) {
-        delete this.checked;
+        this.checked = null;
       } else {
         this.checked = elementValue;
       }


### PR DESCRIPTION
set value to null and check for null instead of only typeof !== 'boolean' to prevent errors stemming from value being set to an undefined value
set checked to null instead of using delete since delete will not work in this instance and it is better to set to null