### PR TITLE
Update styles for ux-icon and ux-input

### DIFF
--- a/src/icons/ux-icon-theme.css
+++ b/src/icons/ux-icon-theme.css
@@ -8,5 +8,5 @@ styles.icon {
 styles.icon > svg {
     width: ${size || '16px'};
     height: ${size || '16px'};
-    fill: ${foreground || $swatches.grey.p700};
+    fill: currentColor;
 }

--- a/src/icons/ux-icon-theme.css
+++ b/src/icons/ux-icon-theme.css
@@ -8,5 +8,5 @@ styles.icon {
 styles.icon > svg {
     width: ${size || '16px'};
     height: ${size || '16px'};
-    fill: currentColor;
+    fill: ${foreground || 'currentColor'};
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,6 @@ export { UxListItem } from './list/ux-list-item';
 export { UxTab } from './tabs/ux-tab';
 export { UxTabs } from './tabs/ux-tabs';
 
-export { Design } from './designs/design';
 export { Themable } from './styles/themable';
 export { StyleEngine } from './styles/style-engine';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export { UxListItem } from './list/ux-list-item';
 export { UxTab } from './tabs/ux-tab';
 export { UxTabs } from './tabs/ux-tabs';
 
+export { Design } from './designs/design';
 export { Themable } from './styles/themable';
 export { StyleEngine } from './styles/style-engine';
 

--- a/src/input/ux-input-theme.css
+++ b/src/input/ux-input-theme.css
@@ -5,6 +5,7 @@ ux-input {
 
   styles.input {
     width: 100%;
+    box-sizing: border-box;
     padding: 6px 0 4px 0;
     margin-bottom: 4px;
     border: 0;


### PR DESCRIPTION
Update styles to resolve two issues. ux-icon will now default to the font color and ux-input will now no longer have the inner input extend beyond its borders.

resolves #91 #92