### PR TITLE
fix: change event surpress timing

### DIFF
--- a/packages/checkbox/src/ux-checkbox.ts
+++ b/packages/checkbox/src/ux-checkbox.ts
@@ -60,8 +60,6 @@ export class UxCheckbox implements UxComponent {
     const element = this.element;
     const checkbox = this.checkbox;
 
-    checkbox.addEventListener('change', stopEvent);
-
     if (element.hasAttribute('id')) {
       const attributeValue = element.getAttribute('id');
 
@@ -89,7 +87,11 @@ export class UxCheckbox implements UxComponent {
     this.themeChanged(this.theme);
   }
 
-  public unbind() {
+  public attached() {
+    this.checkbox.addEventListener('change', stopEvent);
+  }
+
+  public detached() {
     this.checkbox.removeEventListener('change', stopEvent);
   }
 

--- a/packages/input/src/ux-input.ts
+++ b/packages/input/src/ux-input.ts
@@ -44,9 +44,6 @@ export class UxInput implements UxComponent {
     const element = this.element;
     const textbox = this.textbox;
 
-    textbox.addEventListener('change', stopEvent);
-    textbox.addEventListener('input', stopEvent);
-
     if (this.autofocus || this.autofocus === '') {
       this.focused = true;
     }
@@ -100,7 +97,12 @@ export class UxInput implements UxComponent {
     this.themeChanged(this.theme);
   }
 
-  public unbind() {
+  public attached() {
+    this.textbox.addEventListener('change', stopEvent);
+    this.textbox.addEventListener('input', stopEvent);
+  }
+
+  public detached() {
     this.textbox.removeEventListener('change', stopEvent);
     this.textbox.removeEventListener('input', stopEvent);
   }

--- a/packages/radio/src/ux-radio.ts
+++ b/packages/radio/src/ux-radio.ts
@@ -51,8 +51,6 @@ export class UxRadio implements UxComponent {
     const element = this.element;
     const radio = this.radio;
 
-    radio.addEventListener('change', stopEvent);
-
     if (element.hasAttribute('id')) {
       const id = element.id;
 
@@ -82,7 +80,11 @@ export class UxRadio implements UxComponent {
     this.themeChanged(this.theme);
   }
 
-  public unbind() {
+  public attached() {
+    this.radio.addEventListener('change', stopEvent);
+  }
+
+  public detached() {
     this.radio.removeEventListener('change', stopEvent);
   }
 

--- a/packages/switch/src/ux-switch.ts
+++ b/packages/switch/src/ux-switch.ts
@@ -73,6 +73,14 @@ export class UxSwitch implements UxComponent {
     this.disabledChanged(this.disabled);
   }
 
+  public attached() {
+    this.checkbox.addEventListener('change', stopEvent);
+  }
+
+  public detached() {
+    this.checkbox.removeEventListener('change', stopEvent);
+  }
+
   public getChecked() {
     return this.checked;
   }
@@ -143,4 +151,8 @@ export class UxSwitch implements UxComponent {
 
     e.preventDefault();
   }
+}
+
+function stopEvent(e: Event) {
+  e.stopPropagation();
 }

--- a/packages/textarea/src/ux-textarea.ts
+++ b/packages/textarea/src/ux-textarea.ts
@@ -46,9 +46,6 @@ export class UxTextArea implements UxComponent {
     const element = this.element;
     const textbox = this.textbox;
 
-    textbox.addEventListener('change', stopEvent);
-    textbox.addEventListener('input', stopEvent);
-
     if (this.theme != null) {
       this.themeChanged(this.theme);
     }
@@ -87,14 +84,13 @@ export class UxTextArea implements UxComponent {
 
   public attached() {
     this.isAttached = true;
+    this.textbox.addEventListener('change', stopEvent);
+    this.textbox.addEventListener('input', stopEvent);
     this.fitTextContent();
   }
 
   public detached() {
     this.isAttached = false;
-  }
-
-  public unbind() {
     this.textbox.removeEventListener('change', stopEvent);
     this.textbox.removeEventListener('input', stopEvent);
   }


### PR DESCRIPTION
There were issues with removing event of native inputs during unbind, which would be a bit late. I'm not sure what caused the issue but moving them to `attached` and `detached` can help avoid that.