### PR TITLE
WIP feat(Menu): ux-menu element

### DIFF
--- a/packages/menu/def.d.ts
+++ b/packages/menu/def.d.ts
@@ -1,0 +1,4 @@
+declare module '*.html' {
+  const value: string;
+  export = value;
+}

--- a/packages/menu/index.ts
+++ b/packages/menu/index.ts
@@ -1,0 +1,11 @@
+import {
+  FrameworkConfiguration,
+  PLATFORM,
+} from 'aurelia-framework';
+
+export function configure(config: FrameworkConfiguration) {
+  config.globalResources([
+    PLATFORM.moduleName('./ux-menu'),
+    PLATFORM.moduleName('./ux-menuitem')
+  ]);
+}

--- a/packages/menu/ux-menu.css
+++ b/packages/menu/ux-menu.css
@@ -1,0 +1,71 @@
+.ux-menu {
+  display: block;
+}
+
+.ux-menu-anchor {
+  position: absolute;
+}
+
+.ux-menu-panel {
+  position: relative;
+  max-width: 300px;
+  max-height: 400px;
+  padding: 8px 0;
+  background-color: #fff;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
+  transform: scale(.7, 0) translateY(-30px);
+  transform-origin: top left;
+  opacity: 1;
+  transition: transform 0.125s cubic-bezier(0.165, 0.84, 0.44, 1), opacity 0.125s linear;
+  z-index: 1000;
+  overflow-y: auto;
+}
+
+.ux-menu-anchor.active .ux-menu-panel {
+  transform: scale(1, 1) translateY(0);
+}
+
+.ux-menu-anchor.active.faded .ux-menu-panel {
+  opacity: 0;
+}
+
+.ux-menuitem {
+  position: relative;
+  display: flex;
+  min-width: 200px;
+  line-height: 32px;
+  height: 32px;
+  padding: 0 16px 0 24px;
+  user-select: none;
+  cursor: pointer;
+  outline: 0;
+  border: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+  text-decoration: none;
+}
+
+.ux-menuitem:hover,
+.ux-menuitem:active {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.ux-menuitem-text {
+  flex-grow: 1;
+  min-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ux-menuitem-helper-text {
+  flex-shrink: 0;
+  flex-basis: auto;
+  text-align: right;
+  color: rgba(0, 0, 0, 0.5);
+}
+
+.ux-menuitem-helper-text:empty {
+  display: none;
+}

--- a/packages/menu/ux-menu.html
+++ b/packages/menu/ux-menu.html
@@ -1,0 +1,3 @@
+<template class='ux-menu'>
+  <require from='./ux-menu.css'></require>
+</template>

--- a/packages/menu/ux-menu.ts
+++ b/packages/menu/ux-menu.ts
@@ -1,0 +1,190 @@
+import {
+  inject,
+  customElement,
+  inlineView,
+  ViewCompiler,
+  ViewResources,
+  processContent,
+  ViewSlot,
+  View,
+  ViewCompileInstruction,
+  Scope,
+  ViewFactory,
+  bindable,
+  DOM,
+  TaskQueue,
+  ElementEvents,
+  PLATFORM,
+  bindingMode
+} from 'aurelia-framework';
+import * as VIEW from './ux-menu.html';
+
+@inject(DOM.Element, TaskQueue)
+@customElement('ux-menu')
+@inlineView(VIEW)
+@processContent(processMenuContent)
+export class UxMenu {
+
+  private menuFactory: ViewFactory;
+  private menu: View | null;
+  private menuSlot: ViewSlot;
+  private anchor: HTMLElement;
+  private shown: boolean;
+
+  // public menuAnchor: { x: number, y: number; width: number; height: number };
+
+  private owner: View;
+
+  public bindingContext: any;
+  public overrideContext: Scope;
+
+  @bindable({
+    defaultValue: false,
+    defaultBindingMode: bindingMode.twoWay
+  })
+  public open: boolean | string;
+
+  @bindable()
+  public trigger: Element | string | null | undefined;
+
+  constructor(
+    public element: Element,
+    private taskQueue: TaskQueue
+  ) {
+
+  }
+
+  public created(owner: View) {
+    this.owner = owner;
+    this.menuFactory = menuRegistry[this.element.getAttribute(ID_ATTR)!];
+  }
+
+  public bind(bindingContext: any, overrideContext: Scope) {
+    // this.isBound = true;
+    this.bindingContext = bindingContext;
+    this.overrideContext = overrideContext;
+  }
+
+  public attached() {
+    if (!this.menuSlot) {
+      const menuAnchor = this.anchor = document.createElement('div');
+      menuAnchor.className = 'ux-menu-anchor';
+      this.menuSlot = new ViewSlot(document.body.appendChild(menuAnchor), true);
+    }
+    this.openChanged();
+  }
+
+  public detached() {
+    this.hide();
+  }
+
+  // If it's a string, query
+  // If it's an element, use it
+  // else use `<ux-menu/>` element
+  private getTrigger() {
+    let trigger = this.trigger;
+    if (typeof trigger === 'string') {
+      trigger = document.querySelector(trigger);
+    }
+    if (!trigger) {
+      trigger = this.element;
+    }
+    return trigger;
+  }
+
+  private showAt(anchorTo: Element) {
+    const rect = anchorTo.getBoundingClientRect();
+    this.taskQueue.queueMicroTask(() => {
+      Object.assign(this.anchor.style, {
+        left: rect.left + 'px',
+        top: rect.top + 'px',
+        // width: 0,
+        // height: 0,
+        // width: rect.width + 'px',
+        // height: rect.height + 'px'
+      });
+      this.anchor.classList.add('active');
+      const winEvents = new ElementEvents(PLATFORM.global);
+      const onInteract = (e: Event) => {
+        if (e.target === PLATFORM.global || !(this.anchor.contains(e.target as Element))) {
+          this.hide();
+          winEvents.disposeAll();
+        }
+      };
+      winEvents.subscribeOnce('wheel', onInteract, true);
+      winEvents.subscribe('mousedown', onInteract, true);
+    });
+  }
+
+  private get isOpen(): boolean {
+    const open = this.open;
+    return !!(open || open === '');
+  }
+
+  public openChanged() {
+    if (this.isOpen) {
+      this.show();
+    } else {
+      this.hide();
+    }
+  }
+
+  public show() {
+    if (this.shown) {
+      return;
+    }
+    this.shown = true;
+    let menu = this.menu;
+    if (!menu) {
+      menu = this.menu = this.menuFactory.create(this.owner.container);
+    }
+    menu.bind(this.bindingContext, this.overrideContext);
+    this.menuSlot.add(menu);
+    menu.attached();
+    this.showAt(this.getTrigger());
+  }
+
+  public hide() {
+    const menu = this.menu;
+    this.anchor.classList.add('faded');
+    setTimeout(() => {
+      this.anchor.classList.remove('active', 'faded');
+      if (menu) {
+        // detached(), unbind() called inside here
+        this.menuSlot.remove(menu, true, true);
+        this.menu = null;
+      }
+      this.shown = false;
+      this.open = false;
+    }, 100);
+  }
+}
+
+let menuRegistryId = 0;
+const menuRegistry: Record<string, ViewFactory> = {};
+const nextMenuId = () => '' + ++menuRegistryId;
+const ID_ATTR = 'ux-menu-id';
+
+function processMenuContent(
+  compiler: ViewCompiler,
+  resources: ViewResources,
+  node: Element
+): boolean {
+  const menuItemTemplate = document.createDocumentFragment();
+  const menuItemWrapper = menuItemTemplate.appendChild(document.createElement('div'));
+  menuItemWrapper.className = 'ux-menu-panel';
+  let item = node.firstChild;
+  while (item) {
+    if (item.nodeName === 'UX-MENUITEM') {
+      menuItemWrapper.appendChild(item);
+    } else {
+      node.removeChild(item);
+    }
+    item = node.firstChild;
+  }
+  const menuId = nextMenuId();
+  const factory = menuRegistry[menuId] = compiler.compile(menuItemTemplate, resources, ViewCompileInstruction.normal);
+  factory.setCacheSize(1, false);
+  node.setAttribute(ID_ATTR, menuId);
+  return false;
+}

--- a/packages/menu/ux-menuitem.html
+++ b/packages/menu/ux-menuitem.html
@@ -1,0 +1,6 @@
+<template
+  class='ux-menuitem ripple'
+  mousedown.delegate='onMouseDown($event)'>
+  <span class='ux-menuitem-text'>${text}</span>
+  <span class='ux-menuitem-helper-text'>${helperText}</span>
+</template>

--- a/packages/menu/ux-menuitem.ts
+++ b/packages/menu/ux-menuitem.ts
@@ -1,0 +1,90 @@
+import {
+  customElement,
+  ViewCompiler,
+  ViewResources,
+  processAttributes,
+  bindable,
+  inject,
+  DOM,
+  PLATFORM,
+  ElementEvents,
+  inlineView
+} from 'aurelia-framework';
+
+import {
+  PaperRipple
+} from '@aurelia-ux/core';
+
+import * as VIEW from './ux-menuitem.html';
+
+@inject(DOM.Element)
+@customElement('ux-menuitem')
+@processAttributes(ensureContent)
+@inlineView(VIEW)
+export class UxMenuItem {
+
+  @bindable()
+  public text: string;
+
+  @bindable()
+  public helperText: string;
+
+  public ripple: PaperRipple;
+
+  constructor(
+    public readonly element: Element
+  ) {
+
+  }
+
+  public bind() {
+    // empty block
+  }
+
+  public onMouseDown(e: MouseEvent) {
+    this.addWave(e);
+  }
+
+  public addWave(e: MouseEvent) {
+    const target = this.element;
+
+    if (target.classList.contains('ripple')) {
+      let ripple = this.ripple;
+      if (!ripple) {
+        ripple = this.ripple = new PaperRipple();
+        target.appendChild(ripple.$);
+      }
+
+      ripple.downAction(e);
+      new ElementEvents(PLATFORM.global).subscribeOnce('mouseup', () => {
+        ripple.upAction();
+      }, true);
+    }
+  }
+}
+
+function ensureContent(
+  _: ViewCompiler,
+  __: ViewResources,
+  node: Element,
+  attributes: NamedNodeMap
+) {
+  let hasTextBinding = false;
+  const ii = attributes.length;
+  for (let i = 0; ii > i; ++i) {
+    const attr = attributes[i];
+    if (attr.nodeName === 'text') {
+      hasTextBinding = true;
+      break;
+    }
+    const parts = attr.nodeName.split('.');
+    if (parts[0] === 'text') {
+      hasTextBinding = true;
+      continue;
+    }
+  }
+  if (!hasTextBinding) {
+    node.setAttribute('text', node.textContent || '');
+  }
+  node.textContent = '';
+}


### PR DESCRIPTION
Initial work

![ux-menu](https://user-images.githubusercontent.com/9994529/36072546-4813e82a-0f75-11e8-8c9d-83ac82e89092.gif)

Markup:

```html
<ux-menu open.bind='menuOpen' trigger.bind='menuButton'>
  <ux-menuitem click.delegate='zoomIn()' helper-text='ctrl + [+]'>Zoom In</ux-menuitem>
  <ux-menuitem click.delegate='zoomOut()' helper-text='ctrl + [-]'>Zoom Out</ux-menuitem>
  <ux-menuitem click.delegate='copy()' helper-text='ctrl + C'>Copy</ux-menuitem>
  <ux-menuitem click.delegate='paste()' helper-text='ctrl + V'>Paste</ux-menuitem>
  <ux-menuitem click.delegate='closeApp()' helper-text='alt + F4'>Close</ux-menuitem>
</ux-menu>
```

static img

![image](https://user-images.githubusercontent.com/9994529/36072558-8ddbccc4-0f75-11e8-975b-872c713a2ce8.png)

bindings:

  - `open`  => default mode: two way. true = show menu ,false = hide
  - `trigger`: what element will be used to trigger the menu
  - ?? (what else here ?)


TODO:

  - [ ] disabled / enabled states
  - [ ] nested menu
  - [ ] drop up, drop right, drop left configurable
  - [ ] left icon , right icon
  - [ ] theming

@EisenbergEffect @ZHollingshead 