### PR TITLE
feat(css): add fallback properties to CSS

### DIFF
--- a/packages/button/src/ux-button.css
+++ b/packages/button/src/ux-button.css
@@ -9,10 +9,14 @@ ux-button>button {
   outline: none;
   cursor: pointer;
   text-align: center;
+  font-family: inherit;
   font-family: var(--ux-theme--button-font-family, inherit);
+  font-weight: 500;
   font-weight: var(--ux-theme--button-font-weight, 500);
-  text-transform: var(--ux-theme--button-text-transform, 0.5px);
-  letter-spacing: var(--ux-theme--button-letter-spacing, uppercase);
+  text-transform: uppercase;
+  text-transform: var(--ux-theme--button-text-transform, uppercase);
+  letter-spacing: 0.5px;
+  letter-spacing: var(--ux-theme--button-letter-spacing, 0.5px);
 }
 
 ux-button>button::-moz-focus-inner {
@@ -58,59 +62,74 @@ ux-button>button.icon.large {
 
 ux-button>button.raised,
 ux-button>button.fab {
+  background-color: #3F51B5;
   background-color: var(--ux-theme--button-background, var(--ux-design--primary, #3F51B5));
+  color: #fff;
   color: var(--ux-theme--button-foreground, var(--ux-design--primary-foreground, #fff));
 }
 
 ux-button.accent>button.raised,
 ux-button.accent>button.fab {
+  background-color: #FF4081;
   background-color: var(--ux-theme--button-accent-background, var(--ux-design--accent, #FF4081));
+  color: #fff;
   color: var(--ux-theme--button-accent-foreground, var(--ux-design--accent-foreground, #fff));
 }
 
 ux-button>button.raised {
   transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   transition-delay: 0.2s;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12);
   box-shadow: var(--ux-design--elevation2dp, 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12));
 }
 
 ux-button>button.raised:disabled,
 ux-button>button.fab:disabled {
+  background-color: #9E9E9E;
   background-color: var(--ux-theme--button-background-disabled, #9E9E9E);
+  color: #CFD8DC;
   color: var(--ux-theme--button-foreground-disabled, #CFD8DC);
 }
 
 ux-button>button.raised:active {
+  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14),0 1px 10px 0 rgba(0, 0, 0, 0.12),0 2px 4px -1px rgba(0, 0, 0, 0.2);
   box-shadow: var(--ux-design--elevation4dp, 0 4px 5px 0 rgba(0, 0, 0, 0.14),0 1px 10px 0 rgba(0, 0, 0, 0.12),0 2px 4px -1px rgba(0, 0, 0, 0.2));
   transition-delay: 0s;
 }
 
 ux-button>button.raised:disabled:active,
 ux-button>button.fab:disabled:active {
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12);
   box-shadow: var(--ux-design--elevation2dp, 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12));
   transition-delay: 0s;
 }
 
 ux-button>button.raised:focus {
+  box-shadow: 0 0 8px rgba(0,0,0,.18),0 8px 16px rgba(0,0,0,.36);
   box-shadow: var(--ux-design--elevationFocus, 0 0 8px rgba(0,0,0,.18),0 8px 16px rgba(0,0,0,.36));
   transition-delay: 0s;
 }
 
 ux-button>button.raised:disabled:focus,
 ux-button>button.fab:disabled:focus {
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12);
   box-shadow: var(--ux-design--elevation2dp, 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12));
   transition-delay: 0s;
 }
 
 ux-button>button.flat,
 ux-button>button.icon {
+  background-color: transparent;
   background-color: var(--ux-theme--button-flat-background, transparent);
+  color: #3F51B5;
   color: var(--ux-theme--button-flat-foreground, var(--ux-design--primary, #3F51B5));
 }
 
 ux-button.accent>button.flat,
 ux-button.accent>button.icon {
+  background-color: transparent;
   background-color: var(--ux-theme--button-accent-flat-background, transparent);
+  color: #FF4081;
   color: var(--ux-theme--button-accent-flat-foreground, var(--ux-design--accent, #FF4081));
 }
 
@@ -123,6 +142,7 @@ ux-button>button.fab {
   overflow: hidden;
   transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   transition-delay: 0.2s;
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12);
   box-shadow: var(--ux-design--elevation2dp, 0 2px 2px 0 rgba(0, 0, 0, 0.14),0 3px 1px -2px rgba(0, 0, 0, 0.2),0 1px 5px 0 rgba(0, 0, 0, 0.12));
 }
 
@@ -142,11 +162,13 @@ ux-button>button.fab.large {
 }
 
 ux-button>button.fab:active {
+  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14),0 1px 10px 0 rgba(0, 0, 0, 0.12),0 2px 4px -1px rgba(0, 0, 0, 0.2);
   box-shadow: var(--ux-design--elevation4dp, 0 4px 5px 0 rgba(0, 0, 0, 0.14),0 1px 10px 0 rgba(0, 0, 0, 0.12),0 2px 4px -1px rgba(0, 0, 0, 0.2));
   transition-delay: 0s;
 }
 
 ux-button>button.fab:focus {
+  box-shadow: 0 0 8px rgba(0,0,0,.18),0 8px 16px rgba(0,0,0,.36);
   box-shadow: var(--ux-design--elevation-focus, 0 0 8px rgba(0,0,0,.18),0 8px 16px rgba(0,0,0,.36));
   transition-delay: 0s;
 }

--- a/packages/checkbox/src/ux-checkbox.css
+++ b/packages/checkbox/src/ux-checkbox.css
@@ -25,6 +25,7 @@ ux-checkbox>input:disabled {
 }
 
 ux-checkbox>.checkbox {
+  border: solid 2px #616161;
   border: var(--ux-theme--checkbox-border, solid 2px #616161);
   border-radius: 3px;
   display: block;
@@ -35,11 +36,13 @@ ux-checkbox>.checkbox {
 }
 
 ux-checkbox input:hover:not(:disabled) ~ .checkbox {
+  border: solid 2px #FF4081;
   border: var(--ux-theme--checkbox-hover-border, solid 2px var(--ux-design--accent, #FF4081));
   border-radius: 3px;
 }
 
 ux-checkbox input:checked ~.checkbox {
+  border: solid 2px #FF4081;
   border: var(--ux-theme--checkbox-checked-background, var(--ux-design--accent, #FF4081));
   border: var(--ux-theme--checkbox-hover-border, var(--ux-design--accent, #FF4081));
 }
@@ -47,6 +50,7 @@ ux-checkbox input:checked ~.checkbox {
 ux-checkbox>.checkbox>.background-box {
   transform: scale3d(0, 0, 0);
   transition: 100ms;
+  background-color: #FF4081;
   background-color: var(--ux-theme--checkbox-checked-background, var(--ux-design--accent, #FF4081));
   height: inherit;
   width: inherit;
@@ -57,6 +61,7 @@ ux-checkbox input:checked ~.checkbox>.background-box {
 }
 
 ux-checkbox>.checkbox>.background-box>svg {
+  fill: #fff;
   fill: var(--ux-theme--checkbox-checkmark-color, #fff);
   width: 20px;
   height: 20px;
@@ -68,19 +73,23 @@ ux-checkbox.disabled {
 }
 
 ux-checkbox.disabled>.checkbox:hover {
+  border: solid 2px #607D8B;
   border: var(--ux-theme--checkbox-disabled-border, solid 2px #607D8B);
   border-radius: 3px;
 }
 
 ux-checkbox input:disabled ~ .checkbox {
+  border: solid 2px #607D8B;
   border: var(--ux-theme--checkbox-disabled-border, solid 2px #607D8B);
 }
 
 ux-checkbox input:checked:disabled ~ .checkbox>.background-box {
+  background-color: #9E9E9E;
   background-color: var(--ux-theme--checkbox-disabled-background, #9E9E9E);
 }
 
 ux-checkbox input:disabled ~ .checkbox>.background-box::after {
+  border-color: #E0E0E0;
   border-color: var(--ux-theme--checkbox-disabled-foreground, #E0E0E0);
 }
 

--- a/packages/chip-input/src/ux-chip-input.css
+++ b/packages/chip-input/src/ux-chip-input.css
@@ -26,6 +26,7 @@ ux-chip-input {
 
   ux-chip-input>input+div.bottom-border {
     align-self: flex-end;
+    background-color: #9E9E9E;
     background-color: var(--ux-theme--chip-input-foreground, var(--ux-design--primary-light-foreground, #9E9E9E));
     height: 1px;
     margin-top: 2px;
@@ -36,6 +37,7 @@ ux-chip-input {
 
     ux-chip-input:hover>div.bottom-border,
     ux-chip-input>input:focus+div.bottom-border {
+      background-color: #FF4081;
       background-color: var(--ux-design--accent, #FF4081);
     }
 

--- a/packages/chip-input/src/ux-chip.css
+++ b/packages/chip-input/src/ux-chip.css
@@ -7,12 +7,15 @@ ux-chip {
   height: 32px;
   border-radius: 100px;
 
+  background-color:  #FF4081;
   background-color: var(--ux-theme--chip-background, var(--ux-design--accent, #FF4081));
+  color: #FFF;
   color: var(--ux-theme--chip-foreground, var(--ux-design--accent-foreground, #FFF));
 }
 
   ux-chip:focus {
     outline: none;
+    box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.14),0 1px 10px 0 rgba(0, 0, 0, 0.12),0 2px 4px -1px rgba(0, 0, 0, 0.2);
     box-shadow: var(--ux-design--elevation4dp, 0 4px 5px 0 rgba(0, 0, 0, 0.14),0 1px 10px 0 rgba(0, 0, 0, 0.12),0 2px 4px -1px rgba(0, 0, 0, 0.2));
   }
 
@@ -33,7 +36,9 @@ ux-chip {
       justify-content: center;
       align-items: center;
       margin: 0 4px;
+      color: #EEEEEE;
       color: var(--ux-theme--chip-delete-foreground, #EEEEEE);
+      background-color: #9E9E9E;
       background-color: var(--ux-theme--chip-delete-background, #9E9E9E);
       height: 24px;
       width: 24px;

--- a/packages/chip-input/src/ux-tag.css
+++ b/packages/chip-input/src/ux-tag.css
@@ -8,7 +8,9 @@ ux-tag {
 
   border-radius: 2px;
 
+  background-color: #FF4081;
   background-color: var(--ux-theme--tag-background, var(--ux-design--accent, #FF4081));
+  color: #FFF;
   color: var(--ux-theme--tag-foreground, var(--ux-design--accent-foreground, #FFF));
 }
 

--- a/packages/datepicker/src/ux-calendar.css
+++ b/packages/datepicker/src/ux-calendar.css
@@ -13,6 +13,7 @@ ux-calendar div.calendar-row {
 }
 
 ux-calendar .calendar-row.weekdays {
+  color: #E0E0E0;
   color: var(--ux-theme--datepicker-weekday-foreground, #E0E0E0);
 }
 
@@ -33,11 +34,14 @@ ux-calendar div.day-highlight {
 }
 
 ux-calendar div.day-highlight.selected {
+  color: #FFF;
   color: var(--ux-theme--datepicker-selected-day-foreground, var(--ux-design--accent-foreground, #FFF));
+  background-color: #FF4081;
   background-color: var(--ux-theme--datepicker-selected-day-background, var(--ux-design--accent, #FF4081));
 }
 
 ux-calendar div.day-highlight.out-of-range {
+  color: #757575;
   color: var(--ux-theme--datepicker-out-of-range-foreground, #757575);
   cursor: default;
 }

--- a/packages/datepicker/src/ux-datepicker.css
+++ b/packages/datepicker/src/ux-datepicker.css
@@ -4,6 +4,7 @@ ux-datepicker {
 }
 
     ux-datepicker > ux-button > button.icon {
+      color: #333;
       color: var(--ux-theme-datepicker-foreground, #333);
     }
 
@@ -21,11 +22,13 @@ ux-datepicker {
     animation-name: datepicker-background-fade-in;
     animation-duration: 250ms;
     
+    background-color: rgba(0, 0, 0, 0.25);
     background-color: var(--ux-theme--datepicker-overlay, rgba(0, 0, 0, 0.25));
   }
 
 
 ux-datepicker > ux-button svg {
+  fill: currentColor;
   fill: var(--ux-theme--datepicker-calendar-icon, currentColor);
   width: 24px;
   height: 24px;
@@ -37,6 +40,7 @@ ux-datepicker > ux-button svg {
     background-color: rgba(0, 0, 0, 0);
   }
   to {
+    background-color: rgba(0, 0, 0, 0.25);
     background-color: var(--ux-theme--datepicker-overlay, rgba(0, 0, 0, 0.25));
   }
 }

--- a/packages/datepicker/src/ux-picker-dialog.css
+++ b/packages/datepicker/src/ux-picker-dialog.css
@@ -1,5 +1,7 @@
 ux-picker-dialog {
+  color: #262626;
   color: var(--ux-design--control-foreground, var(--ux-swatch--grey-p900, #262626));
+  background-color: #FFF;
   background-color: var(--ux-design--control-background, var(--ux-swatch--white, #FFF));
   width: 300px;
   
@@ -19,7 +21,9 @@ ux-picker-dialog header {
   height: 124px;
   padding: 16px 24px;
   box-sizing: border-box;
+  color: #FFF;
   color: var(--ux-theme--datepicker-header-foreground, var(--ux-design--primary-foreground, #FFF));
+  background: #3F51B5;
   background: var(--ux-theme--datepicker-header-background, var(--ux-design--primary, #3F51B5));
 }
 

--- a/packages/datepicker/src/ux-year-list.css
+++ b/packages/datepicker/src/ux-year-list.css
@@ -13,5 +13,6 @@ ux-year-list>.years {
 
 ux-year-list>.years.selected {
   font-size: 1.75em;
+  color: #FF4081;
   color: var(--ux-design--accent, #FF4081);
 }

--- a/packages/form/src/ux-form.css
+++ b/packages/form/src/ux-form.css
@@ -30,6 +30,8 @@ ux-form ux-field {
 }
 
 ux-form ux-field > label {
+    font-size: 14px;
     font-size: var(--ux-theme--form-label-font-size, 14px);
+    color: #9E9E9E;
     color: var(--ux-theme--form-label-color, #9E9E9E);
 }

--- a/packages/grid/src/ux-grid.css
+++ b/packages/grid/src/ux-grid.css
@@ -1,9 +1,11 @@
 ux-grid {
   display: grid;
   grid-template-columns: repeat(12, 1fr);
+  grid-gap: 16px;
   grid-gap: var(--ux-theme--grid-gutter-spacing, 16px);
   margin-left: auto;
   margin-right: auto;
+  padding: 16px;
   padding: var(--ux-theme--grid-outer-padding, 16px);
   box-sizing: border-box;
   width: 100%;

--- a/packages/icons/src/ux-icon.css
+++ b/packages/icons/src/ux-icon.css
@@ -1,12 +1,16 @@
 ux-icon {
     display: inline-block;
     align-self: center;
+    width: 24px;
     width: var(--ux-theme--icon-size, 24px);
+    height: 24px;
     height: var(--ux-theme--icon-size, 24px);
 }
 
 ux-icon > svg {
+    width: 24px;
     width: var(--ux-theme--icon-size, 24px);
+    height: 24px;
     height: var(--ux-theme--icon-size, 24px);
     fill: currentColor;
 }

--- a/packages/input-info/src/ux-input-info.css
+++ b/packages/input-info/src/ux-input-info.css
@@ -2,6 +2,7 @@ ux-input-info {
   display: flex;
   font-size: 14px;
   width: 100%;
+  color: #757575;
   color: var(--ux-theme--input-info-foreground, #757575);
 }
 
@@ -27,6 +28,7 @@ ux-input-info>.counter {
 }
 
 ux-input.focused+ux-input-info>.counter {
+  color: #FF4081;
   color: var(--ux-design--accent, #FF4081);
 }
 
@@ -35,5 +37,6 @@ ux-input>input[disabled]+ux-input-info {
 }
 
 .has-error+ux-input-info {
+  color:  #F44336;
   color: var(--ux-theme--input-info-error, #F44336);
 }

--- a/packages/input/src/ux-input.css
+++ b/packages/input/src/ux-input.css
@@ -1,6 +1,7 @@
 ux-input {
   display: block;
   width: 100%;
+  color: #212121;
   color: var(--ux-theme--input-foreground, #212121);
 }
 
@@ -14,12 +15,15 @@ ux-input {
     padding-left:0;
     padding-right:0;
     transition: border-color 250ms ease;
+    background-color: transparent;
     background-color: var(--ux-theme--input-background, transparent);
+    border-bottom: 1px solid #9E9E9E;
     border-bottom: var(--ux-theme--input-border-bottom, 1px solid #9E9E9E);
   }
 
     ux-input > input:hover,
     ux-input > input:focus {
+      border-bottom: 1px solid #FF4081;
       border-bottom: var(--ux-theme--input-border-bottom-hover, 1px solid var(--ux-design--accent, #FF4081));
     }
 
@@ -34,7 +38,9 @@ ux-input {
     ux-input > input[readonly],
     ux-input > input[readonly]:hover,
     ux-input > input[readonly]:focus {
+      color: #E0E0E0;
       color: var(--ux-theme--input-disabled-foreground, #E0E0E0);
+      border-bottom: 1px dashed #E0E0E0;
       border-bottom: var(--ux-theme--input-disabled-border-bottom, 1px dashed #E0E0E0);
     }
 
@@ -42,7 +48,9 @@ ux-input {
     padding: 20px 8px;
     font-size: 16px;
     margin-bottom: 0;
+    border: 1px solid #EEEEEE;
     border: var(--ux-theme--input-full-width-border, 1px solid #EEEEEE);
+    background-color: #FFF;
     background-color: var(--ux-theme--input-full-width-background, #FFF);
   }
 
@@ -52,15 +60,20 @@ ux-input {
     ux-input.full-width > input[readonly],
     ux-input.full-width > input[readonly]:hover,
     ux-input.full-width > input[readonly]:focus  {
+      background-color: #EEEEEE;
       background-color: var(--ux-theme--input-full-width-background-disabled, #EEEEEE);
+      border: 1px dashed #E0E0E0;
       border: 1px solid var(--ux-theme--input-disabled-border-bottom, 1px dashed #E0E0E0);
+      color: #E0E0E0;
       color: var(--ux-theme--input-disabled-foreground, #E0E0E0);
     }
   
   ux-input.has-error input {
+    border-bottom-color: #F44336;
     border-bottom-color: var(--ux-theme--input-error, #F44336);
   }
 
   ux-input.full-width.has-error input {
+    border-color: #F44336;
     border-color: var(--ux-theme--input-error, #F44336);
   }

--- a/packages/list/src/ux-list.css
+++ b/packages/list/src/ux-list.css
@@ -1,5 +1,6 @@
 ux-list {
   display: block;
+  background-color: #FFF;
   background-color: var(--ux-theme--list-list-background, #FFF);
 }
 
@@ -9,6 +10,7 @@ ux-list>ux-list-item {
   align-items: center;
   padding: 16px;
   font-size: 16px;
+  color: #616161;
   color: var(--ux-theme--list-list-foreground, #616161);
 }
 
@@ -58,6 +60,7 @@ ux-list>ux-list-item>a.list-content {
 ux-list>.ux-list-item>.list-content>.secondary,
 ux-list>ux-list-item>.list-content>.secondary {
   font-size: 14px;
+  color: #455A64;
   color: var(--ux-theme--list-list-secondary-foreground, #455A64);
 }
 

--- a/packages/radio/src/ux-radio.css
+++ b/packages/radio/src/ux-radio.css
@@ -27,6 +27,7 @@ ux-radio > input:disabled {
 ux-radio > .radio {
   width: 24px;
   height: 24px;
+  border: solid 2px #455A64;
   border: var(--ux-theme--checkbox-border, solid 2px #455A64);
   border-radius: 50%;
   display: inline-flex;
@@ -37,10 +38,12 @@ ux-radio > .radio {
 }
 
 ux-radio input:hover:not(:disabled) ~ .radio {
+  border: solid 2px #FF4081;
   border: var(--ux-theme--radio-hover-border, solid 2px var(--ux-design--accent, #FF4081));
 }
 
 ux-radio input:checked ~ .radio {
+  border: solid 2px #FF4081;
   border: var(--ux-theme--radio-checked-background, var(--ux-design--accent, #FF4081));
   border: var(--ux-theme--radio-hover-border, solid 2px var(--ux-design--accent, #FF4081));
 }
@@ -48,6 +51,7 @@ ux-radio input:checked ~ .radio {
 ux-radio > .radio > .background-box {
   width: 100%;
   height: 100%;
+  background-color: #FF4081;
   background-color: var(--ux-theme--radio-checked-background, var(--ux-design--accent, #FF4081));
   border-radius: 50%;
   transform: scale3d(0, 0, 0);
@@ -59,6 +63,7 @@ ux-radio input:checked ~ .radio > .background-box {
 }
 
 ux-radio > .radio > .background-box > svg {
+  fill: #FFF;
   fill: var(--ux-theme--radio-checkmark-color, #FFF);
 }
 
@@ -68,18 +73,22 @@ ux-radio.disabled {
 }
 
 ux-radio input:disabled ~ .radio:hover {
+  border: solid 2px #9E9E9E;
   border: var(--ux-theme--radio-disabled-border, solid 2px #9E9E9E);
 }
 
 ux-radio input:disabled ~ .radio {
+  border: solid 2px #9E9E9E;
   border: var(--ux-theme--radio-disabled-border, solid 2px #9E9E9E);
 }
 
 ux-radio input:checked:disabled ~ .radio > .background-box {
+  background-color: #9E9E9E;
   background-color: var(--ux-theme--radio-disabled-background, #9E9E9E);
 }
 
 ux-radio input:disabled ~ .radio > .background-box::after {
+  border-color: #E0E0E0;
   border-color: var(--ux-theme--radio-disabled-foreground, #E0E0E0);
 }
 

--- a/packages/switch/src/ux-switch.css
+++ b/packages/switch/src/ux-switch.css
@@ -27,6 +27,7 @@ ux-switch .track {
   width: 32px;
   border: none;
   border-radius: 6px;
+  background-color: #E0E0E0;
   background-color: var(--ux-theme--switch-track, #E0E0E0);
   transition: background-color 150ms ease-in-out;
   position: relative;
@@ -34,14 +35,17 @@ ux-switch .track {
 
 ux-switch input:disabled ~ .track,
 ux-switch input:disabled:checked ~ .track {
+  background-color: #9E9E9E;
   background-color: var(--ux-theme--switch-track-disabled, #9E9E9E);
 }
 
 ux-switch input:disabled ~ .track .indicator, ux-switch input:disabled:checked ~ .track .indicator {
+  background-color: #E0E0E0;
   background-color: var(--ux-theme--switch-indicator-disabled, #E0E0E0);
 }
 
 ux-switch input:checked ~ .track {
+  background-color: #FF80AB;
   background-color: var(--ux-theme--switch-track-active, #FF80AB);
 }
 
@@ -55,6 +59,7 @@ ux-switch .track .indicator {
   top: -3px;
   height: 18px;
   width: 18px;
+  background-color: #FFF;
   background-color: var(--ux-theme--switch-indicator, #FFF);
   border-radius: 50%;
   box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.6);
@@ -63,6 +68,7 @@ ux-switch .track .indicator {
 
 ux-switch input:checked ~ .track .indicator {
   left: calc(100% - 14px);
+  background-color: #FF80AB;
   background-color: var(--ux-theme--switch-indicator-active, #FF80AB);
   box-shadow: 0px 2px 5px 0px rgba(0, 0, 0, 0.4);
 }

--- a/packages/textarea/src/ux-textarea.css
+++ b/packages/textarea/src/ux-textarea.css
@@ -1,6 +1,7 @@
 ux-textarea {
   display: block;
   width: 100%;
+  color: #212121;
   color: var(--ux-theme--textarea-foreground, #212121);
 }
   ux-textarea > textarea {
@@ -13,13 +14,16 @@ ux-textarea {
     padding-left:0;
     padding-right:0;
     transition: border-color 250ms ease;
+    background-color: transparent;
     background-color: var(--ux-theme--textarea-background, transparent);
+    border-bottom: 1px solid #9E9E9E;
     border-bottom: var(--ux-theme--textarea-border-bottom, 1px solid #9E9E9E);
   }
 
     ux-textarea > textarea:hover,
     ux-textarea > textarea:focus {
-      border-bottom-color: var(--ux-theme--textarea-border-bottom-focus, 1px solid var(--ux-design--accent, #FF4081));
+      border-bottom: 1px solid #FF4081;
+      border-bottom: var(--ux-theme--textarea-border-bottom-focus, 1px solid var(--ux-design--accent, #FF4081));
     }
 
     ux-textarea > textarea:focus {
@@ -33,7 +37,9 @@ ux-textarea {
     ux-textarea > textarea[readonly],
     ux-textarea > textarea[readonly]:hover,
     ux-textarea > textarea[readonly]:focus {
+      color: #E0E0E0;
       color: var(--ux-theme--textarea-disabled-foreground, #E0E0E0);
+      border-bottom: 1px dashed #E0E0E0;
       border-bottom: var(--ux-theme--textarea-disabled-border-bottom, 1px dashed #E0E0E0);
     }
     
@@ -45,7 +51,9 @@ ux-textarea {
     padding: 20px 8px;
     margin-bottom: 0;
     font-size: 16px;
+    border: 1px solid #EEEEEE;
     border: var(--ux-theme--textarea-full-width-border, 1px solid #EEEEEE);
+    background-color: #FFF;
     background-color: var(--ux-theme--textarea-full-width-background, #FFF);
   }
 
@@ -55,15 +63,20 @@ ux-textarea {
     ux-textarea.full-width > ux-textarea > textarea[readonly],
     ux-textarea.full-width > ux-textarea > textarea[readonly]:hover,
     ux-textarea.full-width > ux-textarea > textarea[readonly]:focus  {
+      background-color: #EEEEEE;
       background-color: var(--ux-theme--textarea-full-width-background-disabled, #EEEEEE);
-      border: 1px solid var(--ux-theme--textarea-disabled-border-bottom, 1px dashed #E0E0E0);
+      border: 1px dashed #E0E0E0;
+      border: var(--ux-theme--textarea-disabled-border-bottom, 1px dashed #E0E0E0);
+      color: #E0E0E0;
       color: var(--ux-theme--textarea-disabled-foreground, #E0E0E0);
     }
   
   ux-textarea.has-error ux-textarea > textarea {
+    border-bottom-color: #F44336;
     border-bottom-color: var(--ux-theme--textarea-error, #F44336);
   }
 
   ux-textarea.full-width.has-error ux-textarea > textarea {
+    border-color: #F44336;
     border-color: var(--ux-theme--textarea-error, #F44336);
   }


### PR DESCRIPTION
Partial fix for #149.

It adds fallback properties for css properties which have a default set like `var(--x, default)`. No fallbacks where added for `var(--x)` calls.

Adding fallbacks for the css `var(...)` references in the `.ts` files is still missing. Cleanest solution to also fix those is to have/use something like `PAL.Supports.cssVariables` to determine support at runtime.