### PR TITLE
fix(datepicker): call valueChanged on bind to initialize textbox value

### DIFF
--- a/packages/datepicker/src/ux-datepicker.ts
+++ b/packages/datepicker/src/ux-datepicker.ts
@@ -80,6 +80,7 @@ export class UxDatepicker implements UxComponent {
       this.maxTime = dateParse.isValid() ? dateParse : null;
     }
 
+    this.valueChanged(this.value);
     this.themeChanged(this.theme);
   }
 


### PR DESCRIPTION
```ts
export class ViewModel {
  birthday = new Date('2017-03-02');
}
```

```html
<ux-datepicker value.bind="birthday"></ux-datepicker>
```

At the moment, the datepicker's textbox stays empty, while it should display the selected date.

This fix makes sure the textbox is properly initialized when `value` is bound to an actual `Date`.