### PR TITLE
fix(components): components registration

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,28 +1,20 @@
 import { FrameworkConfiguration, PLATFORM } from 'aurelia-framework';
 
-export { UxCardTheme } from '@aurelia-ux/card';
-export { UxButtonTheme } from '@aurelia-ux/button';
-export { UxCheckboxTheme, UxCheckbox, UxCheckboxElement } from '@aurelia-ux/checkbox';
-export { UxChipInputTheme, UxChipTheme } from '@aurelia-ux/chip-input';
-export { UxGridTheme, UxResponsiveUtilities } from '@aurelia-ux/grid';
-export { UxDatepickerTheme } from '@aurelia-ux/datepicker';
-export { UxFormTheme } from '@aurelia-ux/form';
-export { UxInputTheme, UxInput, UxInputElement } from '@aurelia-ux/input';
-export { UxInputInfoTheme } from '@aurelia-ux/input-info';
-export { UxListTheme } from '@aurelia-ux/list';
-export { UxRadioTheme, UxRadio, UxRadioElement } from '@aurelia-ux/radio';
-export { UxTextAreaTheme, UxTextArea, UxTextAreaElement } from '@aurelia-ux/textarea';
-export { UxSwitchTheme, UxSwitch, UxSwitchElement } from '@aurelia-ux/switch';
-export {
-  UxOption,
-  UxOptionElement,
-  UxOptGroup,
-  UxOptGroupElement,
-  UxSelect,
-  UxSelectElement,
-  UxSelectTheme
-} from '@aurelia-ux/select';
-export { UxSliderTheme, UxSlider, UxSliderElement } from '@aurelia-ux/slider';
+export * from '@aurelia-ux/card';
+export * from '@aurelia-ux/button';
+export * from '@aurelia-ux/checkbox';
+export * from '@aurelia-ux/chip-input';
+export * from '@aurelia-ux/grid';
+export * from '@aurelia-ux/datepicker';
+export * from '@aurelia-ux/form';
+export * from '@aurelia-ux/input';
+export * from '@aurelia-ux/input-info';
+export * from '@aurelia-ux/list';
+export * from '@aurelia-ux/radio';
+export * from '@aurelia-ux/textarea';
+export * from '@aurelia-ux/switch';
+export * from '@aurelia-ux/select';
+export * from '@aurelia-ux/slider';
 
 export function configure(config: FrameworkConfiguration) {
   config.plugin(PLATFORM.moduleName('@aurelia-ux/button'));

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,4 @@
-import { FrameworkConfiguration } from 'aurelia-framework';
+import { FrameworkConfiguration, PLATFORM } from 'aurelia-framework';
 
 export { UxCardTheme } from '@aurelia-ux/card';
 export { UxButtonTheme } from '@aurelia-ux/button';
@@ -24,36 +24,20 @@ export {
 } from '@aurelia-ux/select';
 export { UxSliderTheme, UxSlider, UxSliderElement } from '@aurelia-ux/slider';
 
-import { configure as configureButtonComponent } from '@aurelia-ux/button';
-import { configure as configureCardComponent } from '@aurelia-ux/card';
-import { configure as configureCheckboxComponent } from '@aurelia-ux/checkbox';
-import { configure as configureChipComponent } from '@aurelia-ux/chip-input';
-import { configure as configureDatepickerComponent } from '@aurelia-ux/datepicker';
-import { configure as configureGridComponent } from '@aurelia-ux/grid';
-import { configure as configureFormComponent } from '@aurelia-ux/form';
-import { configure as configureInputComponent } from '@aurelia-ux/input';
-import { configure as configureInputInfoComponent } from '@aurelia-ux/input-info';
-import { configure as configureListComponent } from '@aurelia-ux/list';
-import { configure as configureRadioComponent } from '@aurelia-ux/radio';
-import { configure as configureTextareaComponent } from '@aurelia-ux/textarea';
-import { configure as configureSwitchComponent } from '@aurelia-ux/switch';
-import { configure as configureSelectComponent } from '@aurelia-ux/select';
-import { configure as configureSliderComponent } from '@aurelia-ux/slider';
-
 export function configure(config: FrameworkConfiguration) {
-  configureButtonComponent(config);
-  configureCardComponent(config);
-  configureCheckboxComponent(config);
-  configureChipComponent(config);
-  configureDatepickerComponent(config);
-  configureGridComponent(config);
-  configureFormComponent(config);
-  configureInputComponent(config);
-  configureInputInfoComponent(config);
-  configureListComponent(config);
-  configureRadioComponent(config);
-  configureTextareaComponent(config);
-  configureSwitchComponent(config);
-  configureSelectComponent(config);
-  configureSliderComponent(config);
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/button'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/card'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/checkbox'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/chip-input'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/datepicker'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/grid'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/form'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/input'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/input-info'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/list'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/radio'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/textarea'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/switch'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/select'));
+  config.plugin(PLATFORM.moduleName('@aurelia-ux/slider'));
 }


### PR DESCRIPTION
Fixes #233 

I've included another fix, [exposing all (*) variables from components](https://github.com/aurelia/ux/commit/50e70ee0b0c054e8189fe44c903651cc8931f711). I don't see a reason why we would not expose all the variables exposed from the components themselves. But maybe I missed something. Let me know.