### PR TITLE
fix: use esModuleInterop to fix moment rexport

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Check out the [showcase application](https://github.com/aurelia/app-ux-showcase)
 
 **Before The First Build**
 
-`npm ci`: installs dependencies for the base Aurelia UX project
-`npm run bootstrap`: sets up a symlink between all of the packages in the monorepo
-`npm run build`: builds all of the mono repo projects.
+* `npm ci` installs dependencies for the base Aurelia UX project
+* `npm run bootstrap` sets up a symlink between all of the packages in the monorepo
+* `npm run build` builds all of the mono repo projects.
 
 >Note: `npm run build` is very CPU intensive and takes a small period of time on most machines. If you are working within a single component, you might try `npm run build` instead at the component package level.
 

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "esnext",
-    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
     "paths": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "Fred Kleuver <https://github.com/fkleuver>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/commonjs/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/boilerplate/package.json
+++ b/packages/boilerplate/package.json
@@ -18,6 +18,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/commonjs/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/boilerplate/tsconfig.json
+++ b/packages/boilerplate/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "amd",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -20,6 +20,7 @@
     "bigopon <bigopon.777@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/card/tsconfig.json
+++ b/packages/card/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/checkbox/tsconfig.json
+++ b/packages/checkbox/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/chip-input/package.json
+++ b/packages/chip-input/package.json
@@ -22,6 +22,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/chip-input/tsconfig.json
+++ b/packages/chip-input/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -18,6 +18,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "bigopon <bigopon.777@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "esnext",
+    "esModuleInterop": true,
     "rootDir": "src",
     "outDir": "dist/test",
     "noImplicitAny": true,

--- a/packages/datepicker/tsconfig.json
+++ b/packages/datepicker/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/form/tsconfig.json
+++ b/packages/form/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -21,6 +21,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/grid/tsconfig.json
+++ b/packages/grid/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/input-info/package.json
+++ b/packages/input-info/package.json
@@ -18,6 +18,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/input-info/tsconfig.json
+++ b/packages/input-info/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -20,6 +20,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/list/tsconfig.json
+++ b/packages/list/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/radio/tsconfig.json
+++ b/packages/radio/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -19,6 +19,7 @@
     "bigopon <bigopon.777@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/select/tsconfig.json
+++ b/packages/select/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -19,6 +19,7 @@
     "Rick Delhommer <rdelhommer@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/slider/tsconfig.json
+++ b/packages/slider/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/switch/tsconfig.json
+++ b/packages/switch/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -19,6 +19,7 @@
     "Zach Hollingshead <zach.hollingshead@gmail.com>"
   ],
   "main": "dist/commonjs/index.js",
+  "module": "dist/native-modules/index.js",
   "typings": "dist/types/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/textarea/tsconfig.json
+++ b/packages/textarea/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "esnext",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "amd",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "target": "es5",
     "lib": [
       "es2017",


### PR DESCRIPTION
chore: enable esm dist file for various bundlers

More details in https://discourse.aurelia.io/t/aurelia-ux-datepicker-0-18-0-systemjs-cli/3307/2?u=huochunpeng

As you can see the esModuleInterop only affected commonjs and amd build for moment-rexports.