### PR TITLE
Fix date

### DIFF
--- a/packages/datepicker/src/ux-datepicker-theme.ts
+++ b/packages/datepicker/src/ux-datepicker-theme.ts
@@ -32,6 +32,7 @@ export class UxDatepickerTheme implements UxTheme {
   // datepicker modal
   public headerForeground?: string;
   public headerBackground?: string;
+  public pickerBackground?: string;
 
   // calendar properties
   public weekdayForeground?: string;

--- a/packages/datepicker/src/ux-datepicker.ts
+++ b/packages/datepicker/src/ux-datepicker.ts
@@ -45,10 +45,6 @@ export class UxDatepicker implements UxInputComponent {
     datetime: 'L LT'
   };
 
-  @bindable public parsers = {
-    time: ['h:m a', 'H:m']
-  };
-
   @bindable({ defaultBindingMode: bindingMode.twoWay })
   public value: any;
 
@@ -92,13 +88,13 @@ export class UxDatepicker implements UxInputComponent {
     }
 
     if (this.minTime != null) {
-      const dateParse = moment(this.minTime, this.parsers.time);
+      const dateParse = moment(this.minTime, this.formatters.time);
 
       this.minTime = dateParse.isValid() ? dateParse : null;
     }
 
     if (this.maxTime != null) {
-      const dateParse = moment(this.maxTime, this.parsers.time);
+      const dateParse = moment(this.maxTime, this.formatters.time);
 
       this.maxTime = dateParse.isValid() ? dateParse : null;
     }
@@ -146,7 +142,13 @@ export class UxDatepicker implements UxInputComponent {
 
     let parseValue;
 
-    parseValue = this.type === 'time' ? moment(this.textboxValue, this.parsers.time) : moment(this.textboxValue);
+    if (this.type.toLowerCase() === 'date') {
+      parseValue = moment(this.textboxValue, this.formatters.date);
+    } else if (this.type.toLowerCase() === 'time') {
+      parseValue = moment(this.textboxValue, this.formatters.time);
+    } else {
+      parseValue = moment(this.textboxValue, this.formatters.datetime);
+    }
 
     if (parseValue.isValid() &&
       DatetimeUtility.dateOutOfRange(parseValue, this.minDate, this.maxDate, this.config) === false) {
@@ -193,7 +195,7 @@ export class UxDatepicker implements UxInputComponent {
 
   public minTimeChanged(newValue: any) {
     if (newValue != null && newValue instanceof moment === false) {
-      const dateParse = moment(newValue, this.parsers.time);
+      const dateParse = moment(newValue, this.formatters.time);
 
       this.minTime = dateParse.isValid() ? dateParse : null;
     }
@@ -201,7 +203,7 @@ export class UxDatepicker implements UxInputComponent {
 
   public maxTimeChanged(newValue: any) {
     if (newValue != null && newValue instanceof moment === false) {
-      const dateParse = moment(newValue, this.parsers.time);
+      const dateParse = moment(newValue, this.formatters.time);
 
       this.maxTime = dateParse.isValid() ? dateParse : null;
     }

--- a/packages/datepicker/src/ux-datepicker.ts
+++ b/packages/datepicker/src/ux-datepicker.ts
@@ -99,7 +99,7 @@ export class UxDatepicker implements UxInputComponent {
       this.maxTime = dateParse.isValid() ? dateParse : null;
     }
 
-    this.valueChanged(this.value);
+    this.typeChanged(this.type);
     this.themeChanged(this.theme);
   }
 
@@ -142,9 +142,9 @@ export class UxDatepicker implements UxInputComponent {
 
     let parseValue;
 
-    if (this.type.toLowerCase() === 'date') {
+    if (this.type === 'date') {
       parseValue = moment(this.textboxValue, this.formatters.date);
-    } else if (this.type.toLowerCase() === 'time') {
+    } else if (this.type === 'time') {
       parseValue = moment(this.textboxValue, this.formatters.time);
     } else {
       parseValue = moment(this.textboxValue, this.formatters.datetime);
@@ -159,20 +159,32 @@ export class UxDatepicker implements UxInputComponent {
     }
   }
 
+  public typeChanged(newValue: string) {
+    newValue = newValue.toLowerCase();
+    if (newValue === 'time') {
+      this.type = newValue;
+    } else if (newValue === 'date') {
+      this.type = newValue;
+    } else {
+      this.type = 'datetime';
+    }
+    this.valueChanged(this.value);
+  }
+
   public valueChanged(newValue: Date) {
     if (newValue == null) {
       return;
     }
 
-    if (this.type.toLowerCase() === 'datetime') {
+    if (this.type === 'datetime') {
       this.textboxValue = moment(newValue).format(this.formatters.datetime);
     }
 
-    if (this.type.toLowerCase() === 'date') {
+    if (this.type === 'date') {
       this.textboxValue = moment(newValue).format(this.formatters.date);
     }
 
-    if (this.type.toLowerCase() === 'time') {
+    if (this.type === 'time') {
       this.textboxValue = moment(newValue).format(this.formatters.time);
     }
   }

--- a/packages/datepicker/src/ux-picker-dialog.css
+++ b/packages/datepicker/src/ux-picker-dialog.css
@@ -2,7 +2,7 @@ ux-picker-dialog {
   color: #262626;
   color: var(--aurelia-ux--design-control-foreground, #262626);
   background-color: #FFF;
-  background-color: var(--aurelia-ux--design-control-background, #FFF);
+  background-color: var(--aurelia-ux--calendar-picker-background, #FFF);
   width: 300px;
   
   user-select: none;


### PR DESCRIPTION
Because I'm using the `datepicker` in localized website I came to realize a pretty annoying bug. 

Basically the `parsers` and `formatters` bindable are conflicting and create weir behavior. For exemple, if I set the `formatters.bind="{date: 'DD-MM-YYYY'}"` it all works when until the field is blurred. Then the property set value from the formatter is replace by a value parsed again but withe the `parsers` value.

Hopefully it makes sense and this fix can be released soon.

I also added a fix to the theme where the picker needs a background property not connected to the default controls. It's better to keep this picker background in sync with other picker theme properties and have nice defaults that work well. 