### PR TITLE
fix(choice): process value change is new !== old

### DIFF
--- a/packages/core/src/components/ux-choice-container-attribute.ts
+++ b/packages/core/src/components/ux-choice-container-attribute.ts
@@ -82,7 +82,7 @@ export class UxChoiceContainerAttribute {
     }
   }
 
-  public valueChanged(newValue: string | string []) {
+  public valueChanged(newValue: string | string[], oldValue?: string | string[]) {
     if (this.multiple === 'auto') {
       this.multipleChanged(); // call this to ensure isMultiple respect value type
     }
@@ -91,6 +91,8 @@ export class UxChoiceContainerAttribute {
       this.requestProcessValue();
     } else if (!this.isMultiple && Array.isArray(newValue)) {
       this.value = undefined;
+      this.requestProcessValue();
+    } else if (!oldValue || newValue !== oldValue) {
       this.requestProcessValue();
     }
   }

--- a/packages/core/src/components/ux-choice-container-attribute.ts
+++ b/packages/core/src/components/ux-choice-container-attribute.ts
@@ -82,19 +82,16 @@ export class UxChoiceContainerAttribute {
     }
   }
 
-  public valueChanged(newValue: string | string[], oldValue?: string | string[]) {
+  public valueChanged(newValue: string | string[]) {
     if (this.multiple === 'auto') {
       this.multipleChanged(); // call this to ensure isMultiple respect value type
     }
     if (this.isMultiple && typeof newValue === 'string') {
       this.value = [];
-      this.requestProcessValue();
     } else if (!this.isMultiple && Array.isArray(newValue)) {
       this.value = undefined;
-      this.requestProcessValue();
-    } else if (!oldValue || newValue !== oldValue) {
-      this.requestProcessValue();
     }
+    this.requestProcessValue();
   }
 
   public toggleValue(value: string) {

--- a/packages/core/src/components/ux-choice-container-attribute.ts
+++ b/packages/core/src/components/ux-choice-container-attribute.ts
@@ -86,11 +86,17 @@ export class UxChoiceContainerAttribute {
     if (this.multiple === 'auto') {
       this.multipleChanged(); // call this to ensure isMultiple respect value type
     }
+    // Before to process the value, let's make
+    // it's the proper type according to `isMultiple`
     if (this.isMultiple && typeof newValue === 'string') {
       this.value = [];
     } else if (!this.isMultiple && Array.isArray(newValue)) {
       this.value = undefined;
     }
+    // By using requestProcessValue we avoid too many
+    // process in case the value changes quickly
+    // This can happen if the value type must be fixed (above)
+    // or if there are several choice registration in a row
     this.requestProcessValue();
   }
 

--- a/packages/core/src/components/ux-choice-container-attribute.ts
+++ b/packages/core/src/components/ux-choice-container-attribute.ts
@@ -90,8 +90,10 @@ export class UxChoiceContainerAttribute {
     // it's the proper type according to `isMultiple`
     if (this.isMultiple && typeof newValue === 'string') {
       this.value = [];
+      return;
     } else if (!this.isMultiple && Array.isArray(newValue)) {
       this.value = undefined;
+      return;
     }
     // By using requestProcessValue we avoid too many
     // process in case the value changes quickly


### PR DESCRIPTION
Here is a fix for `ux-choice-container` attribute. When we optimized the code in `valueChanged()` we removed an important part... this valueChanged() must also request to process the value if the `newValue` is different thant `oldValue`.

Currently the attribute works well for one-way binding because the right choice is selected anyway. But for two-way binding the valueChanged() needs to process the value.

Ready for review @EisenbergEffect @bigopon 