### PR TITLE
fix(chip-input): stop propagation on ENTER or ESC

### DIFF
--- a/packages/chip-input/src/ux-chip-input.ts
+++ b/packages/chip-input/src/ux-chip-input.ts
@@ -80,6 +80,7 @@ export class UxChipInput implements UxInputComponent {
 
     if (key === 13) {
       this.addChip();
+      event.stopImmediatePropagation();
     }
 
     if (key === 37) {
@@ -90,6 +91,7 @@ export class UxChipInput implements UxInputComponent {
           this.textbox.value = chip;
         }
       }
+      event.stopImmediatePropagation();
     }
   }
 


### PR DESCRIPTION
I noticed that when using a `chip-input` inside a drawer we get a undesired behavior. Both are listening for the keyup change on ENTER and ESC keys.

I suggest that when the chip-input detects the ENTER or ESC keyup it stops the propagation so that other handlers don't act on it as well.

@bigopon what do you think ?