### PR TITLE
fix(input): pass through date input types, default config

### DIFF
--- a/packages/core/src/components/ux-input-component.ts
+++ b/packages/core/src/components/ux-input-component.ts
@@ -1,6 +1,8 @@
 import { UxComponent } from './ux-component';
 import { UxTheme } from '../styles/ux-theme';
 
+export type InputVariant = 'filled' | 'outline';
+
 export interface UxInputComponent extends UxComponent {
   theme: UxTheme;
   label: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export { PaperRipple } from './effects/paper-ripple';
 export { normalizeBooleanAttribute, normalizeNumberAttribute } from './components/html-attributes';
 export { getBackgroundColorThroughParents } from './components/background-color-parent';
 export { UxComponent } from './components/ux-component';
-export { UxInputComponent } from './components/ux-input-component';
+export { UxInputComponent, InputVariant } from './components/ux-input-component';
 export { UxChoiceAttribute } from './components/ux-choice-attribute';
 export { UxChoiceContainerAttribute } from './components/ux-choice-container-attribute';
 export { IController } from './components/i-controller';

--- a/packages/input/src/index.ts
+++ b/packages/input/src/index.ts
@@ -1,13 +1,19 @@
 import { FrameworkConfiguration, bindingMode, PLATFORM } from 'aurelia-framework';
 import { ValueAttributeObserver, EventSubscriber } from 'aurelia-binding';
 import { AureliaUX } from '@aurelia-ux/core';
+import { UxDefaultInputConfiguration } from './ux-default-input-configuration';
 
 export { UxInputTheme } from './ux-input-theme';
 export { UxInput, UxInputElement } from './ux-input';
+export { UxDefaultInputConfiguration };
 
-export function configure(config: FrameworkConfiguration) {
+export function configure(config: FrameworkConfiguration, callback?: (config: UxDefaultInputConfiguration) => void) {
   config.container.get(AureliaUX).registerUxElementConfig(uxInputConfig);
   config.globalResources(PLATFORM.moduleName('./ux-input'));
+  if (typeof callback === 'function') {
+    const defaults = config.container.get(UxDefaultInputConfiguration);
+    callback(defaults);
+  }
 }
 
 const uxInputConfig = {

--- a/packages/input/src/ux-default-input-configuration.ts
+++ b/packages/input/src/ux-default-input-configuration.ts
@@ -1,5 +1,5 @@
 import { UxInputTheme } from './ux-input-theme';
-import { InputVariant } from './ux-input';
+import { InputVariant } from '@aurelia-ux/core';
 
 export class UxDefaultInputConfiguration {
   public theme?: UxInputTheme;

--- a/packages/input/src/ux-default-input-configuration.ts
+++ b/packages/input/src/ux-default-input-configuration.ts
@@ -1,0 +1,8 @@
+import { UxInputTheme } from './ux-input-theme';
+import { InputVariant } from './ux-input';
+
+export class UxDefaultInputConfiguration {
+  public theme?: UxInputTheme;
+  public dense?: boolean;
+  public variant?: InputVariant;
+}

--- a/packages/input/src/ux-input.ts
+++ b/packages/input/src/ux-input.ts
@@ -173,6 +173,9 @@ export class UxInput implements UxInputComponent {
   public typeChanged(newValue: any) {
     if (![
       'text',
+      'date',
+      'time',
+      'datetime-local',
       'password',
       'number',
       'email',
@@ -197,6 +200,7 @@ export class UxInput implements UxInputComponent {
 
   public focus() {
     this.textbox.focus();
+    return true;
   }
 
   public blur() {

--- a/packages/input/src/ux-input.ts
+++ b/packages/input/src/ux-input.ts
@@ -46,16 +46,16 @@ export class UxInput implements UxInputComponent {
   public value: any;
   public textbox: HTMLInputElement;
 
-  constructor(private element: UxInputElement, public styleEngine: StyleEngine, private defaultConfiguration: UxDefaultInputConfiguration) {
+  constructor(private element: UxInputElement, public styleEngine: StyleEngine, defaultConfiguration: UxDefaultInputConfiguration) {
     defineUxInputElementApis(element);
-    if (this.defaultConfiguration.theme !== undefined) {
-      this.theme = this.defaultConfiguration.theme;
+    if (defaultConfiguration.theme !== undefined) {
+      this.theme = defaultConfiguration.theme;
     }
-    if (this.defaultConfiguration.dense !== undefined) {
-      this.dense = this.defaultConfiguration.dense;
+    if (defaultConfiguration.dense !== undefined) {
+      this.dense = defaultConfiguration.dense;
     }
-    if (this.defaultConfiguration.variant !== undefined) {
-      this.variant = this.defaultConfiguration.variant;
+    if (defaultConfiguration.variant !== undefined) {
+      this.variant = defaultConfiguration.variant;
     }
   }
 

--- a/packages/input/src/ux-input.ts
+++ b/packages/input/src/ux-input.ts
@@ -2,7 +2,7 @@ import { customElement, bindable, useView } from 'aurelia-templating';
 import { DOM, PLATFORM } from 'aurelia-pal';
 import { observable, computedFrom } from 'aurelia-binding';
 import { inject } from 'aurelia-dependency-injection';
-import { StyleEngine, UxInputComponent, normalizeBooleanAttribute, getBackgroundColorThroughParents } from '@aurelia-ux/core';
+import { StyleEngine, UxInputComponent, normalizeBooleanAttribute, getBackgroundColorThroughParents, InputVariant } from '@aurelia-ux/core';
 import { UxInputTheme } from './ux-input-theme';
 // tslint:disable-next-line: no-submodule-imports
 import '@aurelia-ux/core/components/ux-input-component.css';
@@ -13,8 +13,6 @@ import { UxDefaultInputConfiguration } from './ux-default-input-configuration';
 export interface UxInputElement extends HTMLElement {
   value: any;
 }
-
-export type InputVariant = 'filled' | 'outline';
 
 @inject(Element, StyleEngine, UxDefaultInputConfiguration)
 @customElement('ux-input')

--- a/packages/input/src/ux-input.ts
+++ b/packages/input/src/ux-input.ts
@@ -8,12 +8,15 @@ import { UxInputTheme } from './ux-input-theme';
 import '@aurelia-ux/core/components/ux-input-component.css';
 // tslint:disable-next-line: no-submodule-imports
 import '@aurelia-ux/core/components/ux-input-component--outline.css';
+import { UxDefaultInputConfiguration } from './ux-default-input-configuration';
 
 export interface UxInputElement extends HTMLElement {
   value: any;
 }
 
-@inject(Element, StyleEngine)
+export type InputVariant = 'filled' | 'outline';
+
+@inject(Element, StyleEngine, UxDefaultInputConfiguration)
 @customElement('ux-input')
 @useView(PLATFORM.moduleName('./ux-input.html'))
 export class UxInput implements UxInputComponent {
@@ -31,7 +34,7 @@ export class UxInput implements UxInputComponent {
   @bindable public label: string;
   @bindable public placeholder: string;
   @bindable public type: any;
-  @bindable public variant: 'filled' | 'outline' = 'filled';
+  @bindable public variant: InputVariant = 'filled';
   @bindable public dense: any = false;
 
   @observable
@@ -43,8 +46,17 @@ export class UxInput implements UxInputComponent {
   public value: any;
   public textbox: HTMLInputElement;
 
-  constructor(private element: UxInputElement, public styleEngine: StyleEngine) {
+  constructor(private element: UxInputElement, public styleEngine: StyleEngine, private defaultConfiguration: UxDefaultInputConfiguration) {
     defineUxInputElementApis(element);
+    if (this.defaultConfiguration.theme !== undefined) {
+      this.theme = this.defaultConfiguration.theme;
+    }
+    if (this.defaultConfiguration.dense !== undefined) {
+      this.dense = this.defaultConfiguration.dense;
+    }
+    if (this.defaultConfiguration.variant !== undefined) {
+      this.variant = this.defaultConfiguration.variant;
+    }
   }
 
   public bind() {
@@ -217,7 +229,7 @@ export class UxInput implements UxInputComponent {
 
   @computedFrom('label')
   get placeholderMode(): boolean {
-    return typeof this.label !== 'string' || this.label.length === 0;
+    return typeof this.label !== 'string' || this.label.length === 0;
   }
 
 }


### PR DESCRIPTION
Returning true is needed to support clicks on a native calendar button.