### PR TITLE
fix(select): apply initial theme value, fix transition

### DIFF
--- a/packages/select/src/ux-select-theme.ts
+++ b/packages/select/src/ux-select-theme.ts
@@ -3,6 +3,8 @@ import { UxTheme } from '@aurelia-ux/core';
 export class UxSelectTheme implements UxTheme {
   public themeKey = 'select';
 
+  static DEFAULT_LIST_TRANSITION = '125ms';
+
   public foreground?: string;
   public foregroundLabel?: string;
   public background?: string;
@@ -29,7 +31,7 @@ export class UxSelectTheme implements UxTheme {
   public listBackground?: string;
   public listForeground?: string;
   public listElevation?: string;
-  public listTransition?: number;
+  public listTransition?: string;
 
   public optionHover?: string;
   public optionFocused?: string;

--- a/packages/select/src/ux-select.ts
+++ b/packages/select/src/ux-select.ts
@@ -144,6 +144,7 @@ export class UxSelect implements UxInputComponent {
     if (!this.winEvents) {
       this.winEvents = new ElementEvents(window);
     }
+    this.themeChanged(this.theme);
     // Initially Synchronize options with value of this element
     this.taskQueue.queueMicroTask(this);
   }

--- a/packages/select/src/ux-select.ts
+++ b/packages/select/src/ux-select.ts
@@ -356,13 +356,16 @@ export class UxSelect implements UxInputComponent {
     }
     this.isCollapsing = true;
     this.optionCtEl.classList.remove('ux-select__list-container--open');
+    const listTransitionString = getComputedStyle(this.element).getPropertyValue('--aurelia-ux--select-list-transition')
+      || UxSelectTheme.DEFAULT_LIST_TRANSITION;
+    const listTransition = parseInt(listTransitionString.replace('ms', ''));
     setTimeout(() => {
       this.optionWrapperEl?.classList.remove('ux-select__list-wrapper--open');
       this.isCollapsing = false;
       this.expanded = false;
       this.setFocusedOption(null);
       this.unsetupListAnchor();
-    }, this.theme && this.theme.listTransition || 125);
+    }, listTransition);
   }
 
   private setFocusedOption(focusedOption: UxOptionElement | null) {


### PR DESCRIPTION
The component might be themed globally in which case `theme` field won't have the actual value.
Plus, number does not work with CSS, it needs to have 'ms'.