### PR TITLE
fix(core): ignore pointer-events on components borders

### DIFF
--- a/packages/core/src/components/ux-input-component.css
+++ b/packages/core/src/components/ux-input-component.css
@@ -137,6 +137,7 @@
   bottom: 0;
   left: 0;
   right: 0;
+  pointer-events: none;
 }
 
 .ux-input-component__border:before {


### PR DESCRIPTION
In outline mode, the "border" element takes the full height of the component. In such scenario it is positioned "above" potential leading and trailing icons and prevents these icons to receive any clicks.

By ignore pointer events on the border element we let the click go through and reach the leading and trailing icons.