### PR TITLE
fix(select): prevent ux-select.blur

### DIFF
--- a/packages/select/src/ux-option.ts
+++ b/packages/select/src/ux-option.ts
@@ -185,8 +185,7 @@ export class UxOption {
 
   public onMouseDown(e: MouseEvent) {
     this.addWave(e);
-    e.preventDefault();
-    return true;
+    return false;
   }
 
   /**

--- a/packages/select/src/ux-option.ts
+++ b/packages/select/src/ux-option.ts
@@ -185,6 +185,7 @@ export class UxOption {
 
   public onMouseDown(e: MouseEvent) {
     this.addWave(e);
+    e.preventDefault();
     return true;
   }
 


### PR DESCRIPTION
Otherwise blur closes the popup before an option receives the click