### PR TITLE
Fix(datepicker): respect locale specific order for weekdays

### DIFF
--- a/packages/datepicker/src/ux-calendar.ts
+++ b/packages/datepicker/src/ux-calendar.ts
@@ -12,7 +12,7 @@ import { PLATFORM } from 'aurelia-pal';
 export class UxCalendar {
   @bindable public theme = null;
 
-  @bindable public weekdays = moment.weekdays();
+  @bindable public weekdays = moment.weekdays(true);
 
   @bindable public minDate: Moment;
   @bindable public maxDate: Moment;


### PR DESCRIPTION
Currently the weekdays in the calendar always start on Sunday. However this is a locale specific thing and we should call `weekdays(true)` in order to follow locale in used by moment.

See https://stackoverflow.com/questions/43520233 for more infos.