### PR TITLE
fix(input): disabled styles for input component

### DIFF
--- a/packages/core/src/components/ux-input-component.css
+++ b/packages/core/src/components/ux-input-component.css
@@ -237,6 +237,13 @@
 .ux-input-component--filled.ux-input-component--disabled .ux-input-component__inner-input,
 .ux-input-component--filled[disabled] .ux-input-component__inner-input,
 .ux-input-component--filled[readonly] .ux-input-component__inner-input{
+  display: none;
+}
+
+.ux-input-component--has-value.ux-input-component--filled.ux-input-component--disabled .ux-input-component__inner-input,
+.ux-input-component--has-value.ux-input-component--filled[disabled] .ux-input-component__inner-input,
+.ux-input-component--has-value.ux-input-component--filled[readonly] .ux-input-component__inner-input {
+  display: block;
   color: #9E9E9E;
   color: var(--disabled-foreground, #9E9E9E);
   -webkit-text-fill-color: #9E9E9E;


### PR DESCRIPTION
When an input field has no value, without this fix the input textbox is displayed with a background color and overflow the ux-input wrapper.

This fix hide the input textbox for disabled empty fields, leaving only the label in position.

Naturally the textbox is displayed for non-empty fields.